### PR TITLE
feat: Add Password Changed Email

### DIFF
--- a/src/email/component/Properties/Resources.Designer.cs
+++ b/src/email/component/Properties/Resources.Designer.cs
@@ -146,6 +146,30 @@ namespace legallead.email.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;h4 style=&quot;color: green&quot; name=&quot;password-changed-heading&quot;&gt;&lt;!-- Template Heading --&gt;&lt;/h4&gt;
+        ///&lt;table name=&quot;password-changed-detail-table&quot; role=&quot;presentation&quot; border=&quot;0&quot; cellspacing=&quot;0&quot; style=&quot;margin-left: 15px; margin-bottom= 15px;&quot; width=&quot;95%&quot;&gt;
+        ///	&lt;tr&gt;
+        ///		&lt;td style=&quot;width: 25%&quot;&gt;
+        ///			&lt;span&gt;User Name:&lt;/span&gt;
+        ///		&lt;/td&gt;
+        ///		&lt;td style=&quot;width: 75%&quot;&gt;
+        ///			&lt;span name=&quot;password-changed-user-name&quot;&gt; - &lt;/span&gt;
+        ///		&lt;/td&gt;
+        ///	&lt;/tr&gt;
+        ///	&lt;tr&gt;
+        ///		&lt;td style=&quot;width: 25%&quot;&gt;
+        ///			&lt;span&gt;Email:&lt;/span&gt;
+        ///		&lt;/td&gt;
+        ///		&lt;td style=&quot;width: 75%&quot;&gt;
+        ///			&lt;sp [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string email_template_html_body_password_changed {
+            get {
+                return ResourceManager.GetString("email_template_html_body_password_changed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;h4 style=&quot;color: green&quot; name=&quot;permission-request-heading&quot;&gt;&lt;!-- Template Heading --&gt;&lt;/h4&gt;
         ///&lt;table name=&quot;permission-request-detail-table&quot; role=&quot;presentation&quot; border=&quot;0&quot; cellspacing=&quot;0&quot; style=&quot;margin-left: 15px; margin-bottom= 15px;&quot; width=&quot;95%&quot;&gt;
         ///	&lt;tr&gt;

--- a/src/email/component/Properties/Resources.resx
+++ b/src/email/component/Properties/Resources.resx
@@ -130,6 +130,9 @@
   <data name="email_template_html_body_locked_account" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\_html\email-template-html-body-locked-account.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>
+  <data name="email_template_html_body_password_changed" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\_html\email-template-html-body-password-changed.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
   <data name="email_template_html_body_permission_request" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>..\_html\email-template-html-body-permission-request.txt;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
   </data>

--- a/src/email/component/RELEASE-NOTES.txt
+++ b/src/email/component/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 
       legallead.email
       - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+      : 3.2.3 - 2024-05-07 - Adding password changed template
       : 3.2.2 - 2024-05-07 - Adding permission change request template
       : 3.2.1 - 2024-05-07 - Adding profile change template
       : 3.2.0 - 2024-05-06 - Adding locked account template
@@ -11,6 +12,7 @@
 
       legallead.email templates
       - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+      : Password Changed - Email to user when password change is completed
       : Permission Changed Request - Email to user when permissions change is requested
       : Profile Changed - Email to user when profile data is updated
       : Locked Account - Email to user if account has been locked

--- a/src/email/component/_html/email-template-html-body-password-changed.txt
+++ b/src/email/component/_html/email-template-html-body-password-changed.txt
@@ -1,0 +1,35 @@
+<h4 style="color: green" name="password-changed-heading"><!-- Template Heading --></h4>
+<table name="password-changed-detail-table" role="presentation" border="0" cellspacing="0" style="margin-left: 15px; margin-bottom= 15px;" width="95%">
+	<tr>
+		<td style="width: 25%">
+			<span>User Name:</span>
+		</td>
+		<td style="width: 75%">
+			<span name="password-changed-user-name"> - </span>
+		</td>
+	</tr>
+	<tr>
+		<td style="width: 25%">
+			<span>Email:</span>
+		</td>
+		<td style="width: 75%">
+			<span name="password-changed-email"> - </span>
+		</td>
+	</tr>
+	<tr>
+		<td name="password-changed-detail-spacer" colspan="2">
+			<hr style="background: #444; height: 1px; border: 0px;" />
+		</td>
+	</tr>
+	<tr>
+		<td name="password-changed-detail" colspan="2">
+			<p>
+				Your account password was recently changed by user request.</p>
+			<p>
+				If you did not initiate this change or have concerns about this email: <br/>
+				Please logout of all legal lead instances, and 
+				<a target="_blank" href="mailto:admin@legallead.co?subject=Account Password Inquiry">contact our security team</a>.
+			</p>
+		</td>
+	</tr>
+</table>

--- a/src/email/component/_html/email-template-html.txt
+++ b/src/email/component/_html/email-template-html.txt
@@ -35,7 +35,7 @@
                 <td colspan="2">
                     <!-- Greeting -->
                     <h3 style="margin-left: 10px;">
-                        <span name="span-greeting">Hello <!-- Greeting.UserName --> </span>,
+                        <span name="span-greeting">Hello <!-- Greeting.UserName --></span>,
                     </h3>
                 </td>
             </tr>

--- a/src/email/component/actions/PasswordChanged.cs
+++ b/src/email/component/actions/PasswordChanged.cs
@@ -1,0 +1,27 @@
+using legallead.email.models;
+using legallead.email.services;
+using legallead.email.utility;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace legallead.email.actions
+{
+    internal class PasswordChanged(MailMessageService messaging, ISmtpService smtp) : BaseEmailAction(messaging, smtp)
+    {
+        public override void OnResultExecuted(ResultExecutedContext context)
+        {
+            if (context.Result is not OkObjectResult okResult) return;
+            if (okResult.Value is not string userName) return;
+            var model = new PasswordChangedResponse(userName);
+            var account = _mailMessageService.SettingsDb.GetUserByUserName(userName).GetAwaiter().GetResult();
+            if (account == null) return;
+            var id = account.Id ?? string.Empty;
+            if (!Guid.TryParse(id, out var _)) return;
+            _mailMessageService.With(TemplateNames.ProfileChanged, id);
+            if (_mailMessageService.Message == null || !CanSend()) return;
+            var body = model.ToHtml(account, _mailMessageService.Message.Body);
+            _mailMessageService.Beautify(body);
+            _smtpService.Send(_mailMessageService.Message, id);
+        }
+    }
+}

--- a/src/email/component/entities/GetUserAccountByUserNameDto.cs
+++ b/src/email/component/entities/GetUserAccountByUserNameDto.cs
@@ -1,0 +1,9 @@
+﻿using legallead.email.attributes;
+
+namespace legallead.email.entities
+{
+    [TargetTable("PRC_EMAIL_GET_ACCOUNT_BY_USER_NAME")]
+    public class GetUserAccountByUserNameDto : GetUserAccountByEmailDto
+    {
+    }
+}

--- a/src/email/component/implementations/PasswordChangedTemplate.cs
+++ b/src/email/component/implementations/PasswordChangedTemplate.cs
@@ -1,0 +1,21 @@
+using legallead.email.models;
+using legallead.email.transforms;
+
+namespace legallead.email.implementations
+{
+    public class PasswordChangedTemplate : HtmlTransformDetailBase
+    {
+
+        public override string BaseHtml => HtmlBase;
+
+        public override List<string> KeyNames => _keynames;
+
+        public override void FetchTemplateParameters(List<UserEmailSettingBo> attributes)
+        {
+        }
+
+        public override Dictionary<string, string?> Substitutions => _substitions;
+        private static readonly string HtmlBase = Properties.Resources.email_template_html_body_password_changed;
+        private static readonly List<string> _keynames = [];
+    }
+}

--- a/src/email/component/interfaces/IUserSettingInfrastructure.cs
+++ b/src/email/component/interfaces/IUserSettingInfrastructure.cs
@@ -8,6 +8,7 @@ namespace legallead.email.interfaces
         Task<List<UserEmailSettingBo>?> GetSettings(UserSettingQuery query);
         Task<UserAccountByEmailBo?> GetUserByEmail(string? email);
         Task<UserAccountByEmailBo?> GetUserBySearchId(string id);
+        Task<UserAccountByEmailBo?> GetUserByUserName(string? userName);
         Task<LogCorrespondenceDto?> Log(string id, string json);
         void LogError(string id, string message);
         void LogSuccess(string id);

--- a/src/email/component/legallead.email.csproj
+++ b/src/email/component/legallead.email.csproj
@@ -7,9 +7,9 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <AssemblyVersion>3.2.2</AssemblyVersion>
-    <FileVersion>3.2.2</FileVersion>
-    <Version>3.2.2</Version>
+    <AssemblyVersion>3.2.3</AssemblyVersion>
+    <FileVersion>3.2.3</FileVersion>
+    <Version>3.2.3</Version>
     <Description>Windows assembly to enable email behaviors from legal leads components.</Description>
     <PackageReleaseNotes>
 			(Please write the package release notes in “RELEASE NOTES.txt”.)

--- a/src/email/component/models/PasswordChangedResponse.cs
+++ b/src/email/component/models/PasswordChangedResponse.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace legallead.email.models
+{
+    public class PasswordChangedResponse(string userName)
+    {
+        public string UserName { get; set; } = userName;
+    }
+}

--- a/src/email/component/models/UserAccountByUserNameBo.cs
+++ b/src/email/component/models/UserAccountByUserNameBo.cs
@@ -1,0 +1,26 @@
+﻿using Dapper;
+
+namespace legallead.email.models
+{
+    public class UserAccountByUserNameBo
+    {
+        public string? Id { get; set; }
+        public string? Email { get; set; }
+        public string? UserName { get; set; }
+
+        public bool IsValid
+        {
+            get
+            {
+                return !string.IsNullOrWhiteSpace(UserName);
+            }
+        }
+
+        public DynamicParameters GetParameters()
+        {
+            var parameters = new DynamicParameters();
+            parameters.Add("user_name", UserName);
+            return parameters;
+        }
+    }
+}

--- a/src/email/component/scaffold-my-tests.ps1
+++ b/src/email/component/scaffold-my-tests.ps1
@@ -1,7 +1,7 @@
 
 param (
-	[string]$template = "PermissionChangeRequested",
-    [string]$templateToken = "permission-request"
+	[string]$template = "PasswordChanged",
+    [string]$templateToken = "password-changed"
 )
 
 $myfolder = [System.IO.Path]::GetDirectoryName( $MyInvocation.MyCommand.Path );

--- a/src/email/component/services/MailMessageService.cs
+++ b/src/email/component/services/MailMessageService.cs
@@ -256,7 +256,8 @@ namespace legallead.email.services
             { TemplateNames.BeginSearchRequested, "Record Search Requested" },
             { TemplateNames.LockedAccountResponse, "Account Status Changed" },
             { TemplateNames.ProfileChanged, "Account Profile Changed" },
-            { TemplateNames.PermissionChangeRequested, "Account Permission Change Requested" }
+            { TemplateNames.PermissionChangeRequested, "Account Permission Change Requested" },
+            { TemplateNames.PasswordChanged, "Password Change Completed" }
         };
         private static readonly List<TemplateNames> CustomTemplates =
         [

--- a/src/email/component/services/UserSettingInfrastructure.cs
+++ b/src/email/component/services/UserSettingInfrastructure.cs
@@ -35,6 +35,18 @@ namespace legallead.email.services
             return JsonConvert.DeserializeObject<UserAccountByEmailBo>(json);
         }
 
+        public async Task<UserAccountByEmailBo?> GetUserByUserName(string? userName)
+        {
+            var query = new UserAccountByUserNameBo { UserName = userName };
+            if (!query.IsValid) return null;
+            var db = _connection.CreateConnection();
+            var parms = query.GetParameters();
+            var sql = $"CALL {new GetUserAccountByUserNameDto().TableName} ( ? );";
+            var response = await _db.QuerySingleOrDefaultAsync<GetUserAccountByUserNameDto>(db, sql, parms);
+            var json = JsonConvert.SerializeObject(response);
+            return JsonConvert.DeserializeObject<UserAccountByEmailBo>(json);
+        }
+
         public async Task<UserAccountByEmailBo?> GetUserBySearchId(string? id)
         {
             if (string.IsNullOrEmpty(id)) return null;

--- a/src/email/component/utility/EmailTransformExtensions.cs
+++ b/src/email/component/utility/EmailTransformExtensions.cs
@@ -73,6 +73,21 @@ namespace legallead.email.utility
             return Substitute(doc, dictionary);
         }
 
+        internal static string ToHtml(this PasswordChangedResponse search,
+            UserAccountByEmailBo? user,
+            string html)
+        {
+            if (string.IsNullOrEmpty(search.UserName)) { return html; }
+            var doc = GetDocument(html);
+            if (doc == null) { return html; }
+            var dictionary = new Dictionary<string, string>()
+            {
+                { "//span[@name='password-changed-user-name']", UserKeyOrDefault(user?.UserName) },
+                { "//span[@name='password-changed-email']", UserKeyOrDefault(user?.Email) },
+            };
+            return Substitute(doc, dictionary);
+        }
+
         private static string GetPermissionItems(PermissionChangeResponse search)
         {
             const string item = "<span style='color:blue;'>{0} : </span><span style='color: gray'>{1}</span><br/>";

--- a/src/email/component/utility/ServiceInfrastructure.cs
+++ b/src/email/component/utility/ServiceInfrastructure.cs
@@ -53,6 +53,7 @@ namespace legallead.email.utility
             services.AddKeyedTransient<IHtmlTransformDetailBase, LockedAccountResponseTemplate>(TemplateNames.LockedAccountResponse.ToString());
             services.AddKeyedTransient<IHtmlTransformDetailBase, ProfileChangedTemplate>(TemplateNames.ProfileChanged.ToString());
             services.AddKeyedTransient<IHtmlTransformDetailBase, PermissionChangeRequestedTemplate>(TemplateNames.PermissionChangeRequested.ToString());
+            services.AddKeyedTransient<IHtmlTransformDetailBase, PasswordChangedTemplate>(TemplateNames.PasswordChanged.ToString());
             // end keyed transients
             // register actions
             services.AddTransient<RegistrationCompleted>();
@@ -61,6 +62,7 @@ namespace legallead.email.utility
             services.AddTransient<LockedAccountResponse>();
             services.AddTransient<ProfileChanged>();
             services.AddTransient<PermissionChangeRequested>();
+            services.AddTransient<PasswordChanged>();
             // end register actions
             services.AddTransient(x =>
             {

--- a/src/email/component/utility/TemplateNames.cs
+++ b/src/email/component/utility/TemplateNames.cs
@@ -9,6 +9,7 @@ namespace legallead.email.utility
         LockedAccountResponse,
         ProfileChanged,
         PermissionChangeRequested,
+        PasswordChanged,
         // end of enumeration
     }
 }

--- a/src/email/component/x-email-templates.json
+++ b/src/email/component/x-email-templates.json
@@ -1,5 +1,10 @@
 [
   {
+    "name": "Password Changed",
+    "description": "Email to user when password change is completed",
+    "date": "2024-05-08"
+  },
+  {
     "name": "Permission Changed Request",
     "description": "Email to user when permissions change is requested",
     "date": "2024-05-08"

--- a/src/email/component/x-email-version.json
+++ b/src/email/component/x-email-version.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "3.2.3",
+    "description": "Adding password changed template",
+    "date": "2024-05-07"
+  },
+  {
     "id": "3.2.2",
     "description": "Adding permission change request template",
     "date": "2024-05-07"

--- a/src/email/tests/MessageMockInfrastructure.cs
+++ b/src/email/tests/MessageMockInfrastructure.cs
@@ -82,6 +82,7 @@ namespace legallead.email.tests
                 services.AddKeyedTransient<IHtmlTransformDetailBase, LockedAccountResponseTemplate>(TemplateNames.LockedAccountResponse.ToString());
                 services.AddKeyedTransient<IHtmlTransformDetailBase, ProfileChangedTemplate>(TemplateNames.ProfileChanged.ToString());
                 services.AddKeyedTransient<IHtmlTransformDetailBase, PermissionChangeRequestedTemplate>(TemplateNames.PermissionChangeRequested.ToString());
+                services.AddKeyedTransient<IHtmlTransformDetailBase, PasswordChangedTemplate>(TemplateNames.PasswordChanged.ToString());
                 // end keyed transients
                 // begin singleton action filters
                 services.AddTransient<BaseEmailActionTemplate>();
@@ -91,6 +92,7 @@ namespace legallead.email.tests
                 services.AddTransient<LockedAccountResponse>();
                 services.AddTransient<ProfileChanged>();
                 services.AddTransient<PermissionChangeRequested>();
+                services.AddTransient<PasswordChanged>();
                 // end singleton action filters
                 services.AddTransient(x =>
                 {

--- a/src/email/tests/_template/template-test-json.txt
+++ b/src/email/tests/_template/template-test-json.txt
@@ -22,5 +22,9 @@
 	{
 		"isTesting": false,
 		"name":  "PermissionChangeRequested"
+	},
+	{
+		"isTesting": true,
+		"name":  "PasswordChanged"
 	}
 ]

--- a/src/email/tests/actions/PasswordChangedTests.cs
+++ b/src/email/tests/actions/PasswordChangedTests.cs
@@ -1,0 +1,133 @@
+using legallead.email.actions;
+using legallead.email.utility;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace legallead.email.tests.actions
+{
+    public class PasswordChangedTests : IDisposable
+    {
+        public PasswordChangedTests()
+        {
+            _ = InitializeProvider();
+        }
+
+        [Theory]
+        [InlineData("2a03793a-7327-4a5a-af11-ddb3851f4b79")]
+        public void ProviderCanGetResultExecutingFiler(string payload)
+        {
+            var exception = Record.Exception(() =>
+            {
+                var provider = InitializeProvider();
+                var context = GetContext(payload, false);
+                if (context is not ResultExecutingContext executedContext) return;
+                var controller = provider.GetService<PasswordChanged>();
+                Assert.NotNull(controller);
+                controller.OnResultExecuting(executedContext);
+            });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("2a03793a-7327-4a5a-af11-ddb3851f4b79")]
+        public void ProviderCanGetResultExecutedFiler(string payload)
+        {
+            var exception = Record.Exception(() =>
+            {
+                var provider = InitializeProvider();
+                var context = GetContext(payload);
+                if (context is not ResultExecutedContext executedContext) return;
+                var controller = provider.GetService<PasswordChanged>();
+                Assert.NotNull(controller);
+                controller.OnResultExecuted(executedContext);
+            });
+            Assert.Null(exception);
+        }
+
+        private static readonly object locker = new();
+
+        private static FilterContext GetContext(string result, bool isExecuted = true)
+        {
+            var collection = new ServiceCollection();
+            collection.AddTransient<PasswordChanged>();
+            collection.AddMvcCore(o =>
+            {
+                o.Filters.AddService<PasswordChanged>();
+            });
+            collection.AddTransient<MockController>();
+            var provider = collection.BuildServiceProvider();
+            var controller = provider.GetRequiredService<MockController>();
+            // Create a default ActionContext (depending on our case-scenario)
+            var actionContext = new ActionContext()
+            {
+                HttpContext = new DefaultHttpContext(),
+                RouteData = new RouteData(),
+                ActionDescriptor = new ActionDescriptor()
+            };
+
+            if (isExecuted)
+            {
+                return new ResultExecutedContext(
+                    actionContext,
+                        new List<IFilterMetadata>(),
+                        new OkObjectResult(result),
+                        controller
+                    );
+            }
+            else
+            {
+                return new ResultExecutingContext(
+                    actionContext,
+                        new List<IFilterMetadata>(),
+                        new OkObjectResult(result),
+                        controller
+                    );
+            }
+        }
+
+        private static ServiceProvider InitializeProvider()
+        {
+            return MessageMockInfrastructure.GetServiceProvider(true);
+        }
+
+        private bool disposedValue;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    lock (locker)
+                    {
+                        ServiceInfrastructure.Provider = null;
+                    }
+                }
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        [ApiController]
+        private sealed class MockController : ControllerBase
+        {
+            [HttpGet]
+            [ServiceFilter(typeof(PasswordChanged))] // Apply the filter to this action method
+            public IActionResult MyAction()
+            {
+                var guid = Guid.NewGuid().ToString();
+                return Ok(guid);
+            }
+        }
+    }
+}

--- a/src/email/tests/entities/GetUserAccountByUserNameDtoTests.cs
+++ b/src/email/tests/entities/GetUserAccountByUserNameDtoTests.cs
@@ -1,0 +1,76 @@
+﻿using legallead.email.entities;
+
+namespace legallead.email.tests.entities
+{
+    public class GetUserAccountByUserNameDtoTests
+    {
+        private static readonly Faker<GetUserAccountByUserNameDto> faker =
+            new Faker<GetUserAccountByUserNameDto>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString())
+            .RuleFor(x => x.Email, y => y.Person.Email)
+            .RuleFor(x => x.UserName, y => y.Person.UserName);
+
+        [Fact]
+        public void DtoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DtoIsBaseDto()
+        {
+            var item = faker.Generate();
+            Assert.IsAssignableFrom<BaseDto>(item);
+        }
+
+        [Fact]
+        public void DtoHasATableName()
+        {
+            var item = faker.Generate();
+            var tb = item.TableName;
+            Assert.False(string.IsNullOrEmpty(tb));
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("Email")]
+        [InlineData("UserName")]
+        public void DtoHasExpectedFieldDefined(string name)
+        {
+            var sut = new GetUserAccountByUserNameDto();
+            var fields = sut.FieldList;
+            Assert.NotNull(fields);
+            Assert.NotEmpty(fields);
+            Assert.Contains(name, fields);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("Email")]
+        [InlineData("UserName")]
+        public void DtoCanReadWriteByIndex(string fieldName)
+        {
+            var demo = faker.Generate();
+            var sut = new GetUserAccountByUserNameDto();
+            var flds = sut.FieldList;
+            var position = flds.IndexOf(fieldName);
+            sut[position] = demo[position];
+            var actual = sut[position];
+            Assert.Equal(demo[position], actual);
+        }
+
+        [Theory]
+        [InlineData("UnmappedId")]
+        [InlineData("")]
+        public void DtoCanReadNonFields(string fieldName)
+        {
+            var demo = faker.Generate();
+            var actual = demo[fieldName];
+            Assert.Null(actual);
+        }
+    }
+}

--- a/src/email/tests/implementations/PasswordChangedTemplateTests.cs
+++ b/src/email/tests/implementations/PasswordChangedTemplateTests.cs
@@ -1,0 +1,68 @@
+using legallead.email.implementations;
+using legallead.email.models;
+
+namespace legallead.email.tests.implementations
+{
+    public class PasswordChangedTemplateTests
+    {
+        [Fact]
+        public void SutCanBeCreated()
+        {
+            var exception = Record.Exception(() => { _ = new PasswordChangedTemplate(); });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void SutHasBaseHtml()
+        {
+            var exception = Record.Exception(() =>
+            {
+                var service = new PasswordChangedTemplate();
+                _ = service.BaseHtml;
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void SutHasKeyNames()
+        {
+            var exception = Record.Exception(() =>
+            {
+                var service = new PasswordChangedTemplate();
+                var names = service.KeyNames;
+                Assert.NotNull(names);
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void SutHasSubstitutions()
+        {
+            var exception = Record.Exception(() =>
+            {
+                var service = new PasswordChangedTemplate();
+                var names = service.Substitutions;
+                Assert.NotNull(names);
+            });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData("abc@temp.com", null)]
+        [InlineData("abc@temp.com", "user-name")]
+        public void SutCanFetchTemplateParameters(string? email, string? userName)
+        {
+            List<UserEmailSettingBo> list = [
+                new() { Email = email, UserName = userName }
+            ];
+            var exception = Record.Exception(() =>
+            {
+                var service = new PasswordChangedTemplate();
+                service.FetchTemplateParameters(list);
+            });
+            Assert.Null(exception);
+        }
+    }
+}

--- a/src/email/tests/models/UserAccountByUserNameBoTests.cs
+++ b/src/email/tests/models/UserAccountByUserNameBoTests.cs
@@ -1,0 +1,58 @@
+﻿using legallead.email.models;
+
+namespace legallead.email.tests.entities
+{
+    public class UserAccountByUserNameBoTests
+    {
+        private static readonly Faker<UserAccountByUserNameBo> faker =
+            new Faker<UserAccountByUserNameBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString())
+            .RuleFor(x => x.Email, y => y.Person.Email)
+            .RuleFor(x => x.UserName, y => y.Person.UserName);
+
+        [Fact]
+        public void DtoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void DtoHasExpectedFieldDefined()
+        {
+            var sut = new UserAccountByUserNameBo();
+            var test = faker.Generate();
+            Assert.NotEqual(sut.Id, test.Id);
+            Assert.NotEqual(sut.Email, test.Email);
+            Assert.NotEqual(sut.UserName, test.UserName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("     ")]
+        [InlineData("1")]
+        [InlineData("2")]
+        [InlineData("3")]
+        [InlineData("4")]
+        public void DtoCanValidate(string? fakeUserName)
+        {
+            var test = faker.Generate();
+            bool isFake = string.IsNullOrWhiteSpace(fakeUserName);
+            if (isFake) test.UserName = fakeUserName;
+            var actual = test.IsValid;
+            Assert.NotEqual(isFake, actual);
+        }
+
+        [Fact]
+        public void DtoCanGetParameters()
+        {
+            var test = faker.Generate();
+            var parms = test.GetParameters();
+            Assert.NotNull(parms);
+        }
+    }
+}

--- a/src/email/tests/services/MessageSendLiveTest.cs
+++ b/src/email/tests/services/MessageSendLiveTest.cs
@@ -14,6 +14,7 @@ namespace legallead.email.tests.services
         [InlineData(TemplateNames.LockedAccountResponse)]
         [InlineData(TemplateNames.ProfileChanged)]
         [InlineData(TemplateNames.PermissionChangeRequested)]
+        [InlineData(TemplateNames.PasswordChanged)]
         public void MessageCanSendLiveEmail(TemplateNames template)
         {
             if (!Debugger.IsAttached) return;

--- a/src/email/tests/update-config-test.ps1
+++ b/src/email/tests/update-config-test.ps1
@@ -14,7 +14,7 @@ function doesNodeExist( $source, $search )
 
 $myfolder = [System.IO.Path]::GetDirectoryName( $MyInvocation.MyCommand.Path );
 $src = [System.IO.Path]::Combine( $myfolder, "_template\template-test-json.txt" );
-$name = "PermissionChangeRequested"
+$name = "PasswordChanged"
 
 if ( [System.IO.File]::Exists( $src ) -eq $false ) { return; }
 


### PR DESCRIPTION
# Discussion
As app developer,
I want to send email to user
When that user changes their password.

## API
No changes needed.

## Email
Email component should translate the `OkObjectResult` returned from permissions controller.
- added new model objects to deserialize the result content
- added code coverage confirming ability to map result into actionable object
- added email template, action and translation