### PR TITLE
Adding support for headless browsing

### DIFF
--- a/src/api/legallead.models/legallead.models.v1.csproj
+++ b/src/api/legallead.models/legallead.models.v1.csproj
@@ -42,6 +42,12 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>legallead.reader.component.tests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service.tests</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/core/legallead.core/component/records.search/legallead.records.search.csproj
+++ b/src/core/legallead.core/component/records.search/legallead.records.search.csproj
@@ -197,5 +197,11 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>legallead.records.search.tests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service.tests</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 </Project>

--- a/src/core/legallead.core/tests/legallead.records.search.tests/Web/HarrisCriminalRealTimeTests.cs
+++ b/src/core/legallead.core/tests/legallead.records.search.tests/Web/HarrisCriminalRealTimeTests.cs
@@ -32,7 +32,9 @@ namespace legallead.records.search.UnitTests.Web
             {
                 var src = SrcFile.Replace(@"\", "/");
                 var url = string.Concat("file:", "///", src);
-                GetDriver = new FirefoxDriver
+                var options = new FirefoxOptions();
+                options.AddArgument("-headless");
+                GetDriver = new FirefoxDriver(options)
                 {
                     Url = url
                 };

--- a/src/db/component/legallead.jdbc/legallead.jdbc.csproj
+++ b/src/db/component/legallead.jdbc/legallead.jdbc.csproj
@@ -40,6 +40,12 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>legallead.reader.component.tests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service.tests</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/logging/legallead.logging/legallead.logging.csproj
+++ b/src/logging/legallead.logging/legallead.logging.csproj
@@ -50,6 +50,12 @@
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
 			<_Parameter1>legallead.reader.component.tests</_Parameter1>
 		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service</_Parameter1>
+		</AssemblyAttribute>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>legallead.reader.service.tests</_Parameter1>
+		</AssemblyAttribute>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Problem Statement  

As a user,
I want to be able to perform searches on my local environment
So that I do not need to wait or depend on external processes to serve my requests.

# Corrections
- Adding internals visibility to new component legallead.reader.service which will ultimately be installed to local user machines to handle queue processing.