### PR TITLE
collin county - driver options

### DIFF
--- a/src/core/legallead.core/component/records.search/Classes/CollinWebInteractive.cs
+++ b/src/core/legallead.core/component/records.search/Classes/CollinWebInteractive.cs
@@ -94,11 +94,14 @@ namespace legallead.records.search.Classes
                     {
                         continue;
                     }
-
-                    action.Act(item);
-                    if (item.ActionName == "click" && item.DisplayName == "search-type-hyperlink")
+                    if (item.DisplayName == "case-type-search")
                     {
-                        Thread.Sleep(1250);
+                        WaitSequence(1, driver);
+                    }
+                    action.Act(item);
+                    if (item.DisplayName == "search-type-hyperlink" || item.DisplayName == "case-type-search")
+                    {
+                        WaitSequence(4, driver);
                     }
                     cases = ExtractCaseData(results, cases, actionName, action);
                     if (string.IsNullOrEmpty(caseList) && !string.IsNullOrEmpty(action.OuterHtml))
@@ -317,5 +320,40 @@ namespace legallead.records.search.Classes
                     endingDate.Date.ToString(CommonKeyIndexes.DateTimeShort, formatDate);
             }
         }
+        private static void WaitSequence(int delay, IWebDriver driver)
+        {
+            for (int i = 0; i < delay; i++)
+            {
+                Thread.Sleep(450);
+                driver.WaitForNavigation();
+                Proceed(driver);
+            }
+        }
+
+        private static void Proceed(IWebDriver driver)
+        {
+            var by = By.CssSelector("#proceed-button");
+            var element = driver.TryFindElement(by);
+            if (element == null) { return; }
+            var alert = GetAlert(driver);
+            alert?.Accept();
+            var command = "document.getElementById('proceed-button').click()";
+            var jse = (IJavaScriptExecutor)driver;
+            jse.ExecuteScript(command);
+        }
+
+        private static IAlert? GetAlert(IWebDriver driver)
+        {
+            try
+            {
+                return driver.SwitchTo().Alert();
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+
     }
 }

--- a/src/core/legallead.core/component/records.search/DriverFactory/BaseChromeProvider.cs
+++ b/src/core/legallead.core/component/records.search/DriverFactory/BaseChromeProvider.cs
@@ -31,6 +31,8 @@ namespace legallead.records.search.DriverFactory
             {
                 options.BinaryLocation = binaryName;
             }
+            options.AddArgument("guest");
+            options.AddUserProfilePreference("reduce-security-for-testing", null);
             options.AddUserProfilePreference("download.prompt_for_download", false);
             options.AddUserProfilePreference("download.directory_upgrade", true);
             options.AddUserProfilePreference("download.default_directory", CalculateDownloadPath());

--- a/src/core/legallead.core/component/records.search/DriverFactory/ChromeProvider.cs
+++ b/src/core/legallead.core/component/records.search/DriverFactory/ChromeProvider.cs
@@ -25,6 +25,8 @@ namespace legallead.records.search.DriverFactory
                 {
                     options.AddArgument("headless");
                 }
+                options.AddArgument("guest");
+                options.AddUserProfilePreference("reduce-security-for-testing", null);
                 options.AddUserProfilePreference("download.prompt_for_download", false);
                 options.AddUserProfilePreference("download.directory_upgrade", true);
                 options.AddUserProfilePreference("download.default_directory", CalculateDownloadPath());


### PR DESCRIPTION
## Problem:   
   
When a user attempts to perform Collin county search   
New items in the search workflow are raising errors that prevent search completion.   
   
## Resolution:   
### Web Interactive   
1. (Collin Interactive) Added pause and wait-for-navigation instructions after login and after search submission      
2. (Collin Login) Added pause and wait-for-navigation in login-submit process   
   
### Chrome Driver      
1. (Chrome) added option guest to address password strength   
2. (Chrome) added preference to set security to testing in sessions   
3. (Chrome) added prompt behavior to accept unexpected dialog      
   
### FireFox   
1. (FireFox) added preference to set safe browsing in sessions   
2. (FireFox) added prompt behavior to accept unexpected dialog