### PR TITLE
Search worker - prevent concurrent requests

### DIFF
--- a/mysql/testing/list-search-records-by-county.sql
+++ b/mysql/testing/list-search-records-by-county.sql
@@ -1,0 +1,43 @@
+SET @countyName = 'TARRANT';
+
+DROP temporary table if exists tmp_filter_county_search;
+CREATE temporary table tmp_filter_county_search
+SELECT *
+FROM
+(
+	SELECT
+		q.Id, 
+		q.UserId, 
+		q.StartDate, 
+		q.EndDate, 
+		q.ExpectedRows, 
+		q.CreateDate,
+		UPPER( JSON_VALUE( q.`Line`, "$.county.name") ) `County`,
+		convert( from_unixtime( LEFT( JSON_VALUE( q.`Line`, "$.start"), 10 ) ) , DATE) `BeginDt`,
+		convert( from_unixtime( LEFT( JSON_VALUE( q.`Line`, "$.end"), 10 ) ) , DATE) `EndingDt`
+	FROM
+	(
+	SELECT s.*, CONVERT(`Line` USING UTF8MB4) `Line`
+	  FROM SEARCH s
+	  LEFT 
+	  JOIN 	SEARCHREQUEST sr
+	  ON	s.Id = sr.SearchId
+	  WHERE sr.LineNbr = 1
+        AND s.EndDate is not null
+        AND s.ExpectedRows is not null
+	) q
+) qq
+WHERE qq.County = @countyName
+  -- AND qq.ExpectedRows = 0
+ORDER BY qq.CreateDate DESC;
+
+select * from tmp_filter_county_search;
+
+/*
+UPDATE 	SEARCH s
+JOIN	tmp_filter_county_search t
+  ON 	s.Id = t.Id
+  SET	s.EndDate = NULL,
+		s.ExpectedRows = null
+WHERE	s.Id = '84460a7a-2e8e-11ef-99ce-0af7a01f52e9';
+*/

--- a/mysql/testing/queue-search-all-users-by-county-and-status.sql
+++ b/mysql/testing/queue-search-all-users-by-county-and-status.sql
@@ -1,0 +1,21 @@
+SET @countyFilter = null; -- 'HARRIS';
+SET @statusFilter = null; -- '10 - Error';
+
+SELECT
+		v.*,
+        s.StartDate RequestStartDt,
+        s.EndDate RequestEndDt
+FROM VW_SEARCH_STATUS_ALL v
+JOIN SEARCH s
+  ON s.Id = v.Id
+WHERE 1 = 1
+AND v.CountyName 		= CASE WHEN @countyFilter IS NULL THEN v.CountyName ELSE @countyFilter END
+AND v.SearchProgress 	= CASE WHEN @statusFilter IS NULL THEN v.SearchProgress ELSE @statusFilter END;
+
+
+/*
+UPDATE 	SEARCH s
+  SET	s.EndDate = NULL,
+		s.ExpectedRows = null
+WHERE	s.Id = '7b10201a-40b2-11ef-99ce-0af7a01f52e9';
+*/

--- a/mysql/testing/search-working-message-table.sql
+++ b/mysql/testing/search-working-message-table.sql
@@ -1,0 +1,29 @@
+drop temporary table if exists tmp_WORKINGMESSAGE;
+
+create temporary table tmp_WORKINGMESSAGE (
+	`Id` int not null,
+    `Message` varchar(50) not null,
+	PRIMARY KEY (`Id`)
+);
+insert tmp_WORKINGMESSAGE ( `Id`, `Message` )
+values
+	( 0, 'process beginning' )
+	,( 1, 'parameter evaluation' )
+	,( 2, 'parameter conversion to search request' )
+	,( 3, 'search request processing' )
+	,( 4, 'excel content conversion' )
+	,( 5, 'excel content serialization' )
+	,( 6, 'process completed' );
+
+drop table if exists SEARCHWORKINGMESSAGE;
+create table SEARCHWORKINGMESSAGE (
+	`Id` int not null,
+    `Message` varchar(50) not null,
+	PRIMARY KEY (`Id`)
+);
+
+INSERT SEARCHWORKINGMESSAGE
+( `Id`, `Message` )
+SELECT `Id`, `Message` FROM tmp_WORKINGMESSAGE;
+
+SELECT * FROM SEARCHWORKINGMESSAGE;

--- a/mysql/testing/search-working-status-table.sql
+++ b/mysql/testing/search-working-status-table.sql
@@ -1,0 +1,25 @@
+drop temporary table if exists tmp_WORKINGSTATUS;
+
+create temporary table tmp_WORKINGSTATUS (
+	`Id` int not null,
+    `Message` varchar(15) not null,
+	PRIMARY KEY (`Id`)
+);
+insert tmp_WORKINGSTATUS ( `Id`, `Message` )
+values
+	( 0, 'begin' )
+	,( 1, 'complete' )
+	,( 2, 'failed' );
+
+drop table if exists SEARCHWORKINGSTATUS;
+create table SEARCHWORKINGSTATUS (
+	`Id` int not null,
+    `Message` varchar(15) not null,
+	PRIMARY KEY (`Id`)
+);
+
+INSERT SEARCHWORKINGSTATUS
+( `Id`, `Message` )
+SELECT `Id`, `Message` FROM tmp_WORKINGSTATUS;
+
+SELECT * FROM SEARCHWORKINGSTATUS;

--- a/mysql/testing/search-working-table-insert.sql
+++ b/mysql/testing/search-working-table-insert.sql
@@ -1,0 +1,70 @@
+SET @js =
+TRIM('
+{
+ "src": "LOCALHOST",
+ "ids": [
+	{ "id": "7b10201a-40b2-11ef-99ce-0af7a01f52e9" },
+	{ "id": "7ac5a7c9-40b2-11ef-99ce-0af7a01f52e9" },
+	{ "id": "01caaf9e-40b0-11ef-99ce-0af7a01f52e9" },
+	{ "id": "0169cde5-40b0-11ef-99ce-0af7a01f52e9" },
+	{ "id": "b20e6dfe-3c74-11ef-99ce-0af7a01f52e9" },
+	{ "id": "512b03d7-3c06-11ef-99ce-0af7a01f52e9" },
+	{ "id": "4f7cdde2-3c06-11ef-99ce-0af7a01f52e9" },
+	{ "id": "4dadaaf9-3c06-11ef-99ce-0af7a01f52e9" },
+	{ "id": "d6d2f121-3c04-11ef-99ce-0af7a01f52e9" },
+	{ "id": "d6465dcc-3c04-11ef-99ce-0af7a01f52e9" },
+	{ "id": "912d38ca-3c04-11ef-99ce-0af7a01f52e9" },
+	{ "id": "865268fc-3c02-11ef-99ce-0af7a01f52e9" },
+	{ "id": "7ecd00f3-3c01-11ef-99ce-0af7a01f52e9" },
+	{ "id": "3a772d24-363d-11ef-99ce-0af7a01f52e9" },
+	{ "id": "c07d1957-363c-11ef-99ce-0af7a01f52e9" }
+ ]
+}');
+/*
+	status type
+    0 - begin
+    1 - complete
+    2 - failed
+*/
+
+drop temporary table if exists tmp_queue_start_requested;
+
+SET @computerName = JSON_VALUE( @js, "$.src" );
+create temporary table tmp_queue_start_requested
+SELECT @computerName `Cpu`, `Index`, utc_timestamp() CreateDate
+FROM
+(
+	SELECT ii.`Index`
+	FROM JSON_TABLE( @js, "$.ids[*]" COLUMNS (`Index` VARCHAR(50) PATH "$.id" )) ii
+	GROUP BY ii.`Index`
+) i
+LEFT JOIN SEARCH s
+ON i.`Index` = s.Id
+WHERE s.Id is not null;
+
+UPDATE SEARCHWORKING w
+  JOIN tmp_queue_start_requested t
+    ON t.`Index` = w.SearchId
+    SET
+	MessageId = 0,
+    StatusId = 0,
+    MachineName = t.`Cpu`,
+    CreateDate = t.CreateDate,
+    CompletionDate = NULL
+WHERE	w.Id != '';
+
+INSERT SEARCHWORKING 
+(
+	SearchId, MessageId, StatusId, MachineName, CreateDate, CompletionDate
+)
+SELECT 
+	t.`Index` SearchId, 
+    0 MessageId, 
+    0 StatusId, 
+    t.`Cpu` MachineName, 
+    t.CreateDate, 
+    NULL CompletionDate
+  FROM tmp_queue_start_requested t
+  LEFT JOIN SEARCHWORKING w
+  ON	t.`Index` = w.SearchId
+  WHERE	w.Id is null;

--- a/mysql/testing/search-working-table-update.sql
+++ b/mysql/testing/search-working-table-update.sql
@@ -1,0 +1,42 @@
+SET @js = '{
+ "src": "LOCALHOST",
+ "id": "7b10201a-40b2-11ef-99ce-0af7a01f52e9",
+ "messageId": 0,
+ "statusId": 0
+ }';
+ SET @lastUpdate = utc_timestamp();
+ SET @statusFailed = (SELECT Id FROM SEARCHWORKINGSTATUS WHERE `Message` = 'failed');
+ SET @statusCompleted = (SELECT Id FROM SEARCHWORKINGSTATUS WHERE `Message` = 'complete');
+ SET @messageCompleted = (SELECT Id FROM SEARCHWORKINGMESSAGE WHERE `Message` = 'process completed');
+ 
+ SET @statusFailed = CASE WHEN @statusFailed IS NULL THEN 2 ELSE @statusFailed END;
+ SET @statusCompleted = CASE WHEN @statusCompleted IS NULL THEN 1 ELSE @statusCompleted END;
+ SET @messageCompleted = CASE WHEN @messageCompleted IS NULL THEN 6 ELSE @messageCompleted END;
+ 
+DROP TEMPORARY TABLE IF EXISTS tmp_working_parms;
+CREATE TEMPORARY TABLE tmp_working_parms
+SELECT
+	SearchId, MessageId, StatusId, MachineName,
+    CASE 
+    WHEN StatusId = @statusCompleted AND MessageId = @messageCompleted THEN @lastUpdate 
+    WHEN StatusId = @statusFailed THEN @lastUpdate 
+    ELSE NULL END CompletionDate
+FROM
+(
+SELECT 
+	CAST( JSON_VALUE( @js, "$.id" ) AS CHAR(36)) SearchId,
+	CONVERT( JSON_VALUE( @js, "$.messageId" ), SIGNED ) MessageId,
+	CONVERT( JSON_VALUE( @js, "$.statusId" ), SIGNED ) StatusId,
+	LEFT( TRIM( JSON_VALUE( @js, "$.src" ) ), 256 )  MachineName
+) m;
+
+UPDATE	SEARCHWORKING w
+  JOIN	tmp_working_parms p
+    ON 	w.SearchId = p.SearchId
+   SET
+   w.MessageId = p.MessageId,
+   w.StatusId = p.StatusId,
+   w.MachineName = p.MachineName,
+   w.CompletionDate = p.CompletionDate,
+   w.LastUpdateDt = @lastUpdate
+ WHERE	w.Id != '';

--- a/mysql/testing/search-working-table.sql
+++ b/mysql/testing/search-working-table.sql
@@ -1,0 +1,35 @@
+/*
+	create table to store items where a search is currently processing
+    so that only one processor will work a given series of requests
+
+CREATE TABLE `SEARCHDETAIL` (
+  `Id` char(36) NOT NULL DEFAULT (cast(uuid() as char(36) charset utf8mb4)),
+  `SearchId` char(36) NOT NULL,
+  `LineNbr` int NOT NULL,
+  `Line` mediumblob,
+  `CreateDate` datetime NOT NULL DEFAULT (utc_timestamp()),
+  PRIMARY KEY (`Id`),
+  UNIQUE KEY `unq_SEARCHDETAIL_searchid_linenbr` (`SearchId`,`LineNbr`),
+  CONSTRAINT `fk_searchdetail__search_id` FOREIGN KEY (`SearchId`) REFERENCES `SEARCH` (`Id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+
+*/
+drop table if exists SEARCHWORKING;
+create table SEARCHWORKING (
+	`Id` char(36) NOT NULL DEFAULT (cast(uuid() as char(36) charset utf8mb4)),
+	`SearchId` char(36) NOT NULL,
+	`MessageId` int NOT NULL DEFAULT( 0 ),
+	`StatusId` int NOT NULL DEFAULT( 0 ),
+	`MachineName` varchar(256),
+	`CreateDate` datetime NOT NULL DEFAULT (utc_timestamp()),
+    `LastUpdateDt` datetime NOT NULL DEFAULT (utc_timestamp()),
+	`CompletionDate` datetime NULL,
+	PRIMARY KEY (`Id`)
+	, CONSTRAINT `fk_search_working__search_id` FOREIGN KEY (`SearchId`) REFERENCES `SEARCH` (`Id`)
+	, CONSTRAINT `fk_search_working__message_id` FOREIGN KEY (`MessageId`) REFERENCES `SEARCHWORKINGMESSAGE` (`Id`)
+	, CONSTRAINT `fk_search_working__status_id` FOREIGN KEY (`StatusId`) REFERENCES `SEARCHWORKINGSTATUS` (`Id`)
+);
+
+select *
+  from SEARCHWORKING;

--- a/src/core/legallead.core/component/records.search/Classes/SettingsManager.cs
+++ b/src/core/legallead.core/component/records.search/Classes/SettingsManager.cs
@@ -194,7 +194,7 @@ namespace legallead.records.search.Classes
             {
                 idx += 1;
                 string cleaned = Path.GetFileNameWithoutExtension(fileName);
-                cleaned = string.Format(cultureInfo, "{0}_{1}.xml", cleaned, idx.ToString("D9", numberInfo));
+                cleaned = string.Format(cultureInfo, "{0}_{1}.xml", cleaned, idx.ToString("D4", numberInfo));
                 targetFile = string.Format(cultureInfo, "{0}/{1}", Path.GetDirectoryName(fileName), cleaned);
             }
             fileName = targetFile;

--- a/src/core/legallead.core/tests/legallead.records.search.tests/CollinInteractiveTest.cs
+++ b/src/core/legallead.core/tests/legallead.records.search.tests/CollinInteractiveTest.cs
@@ -3,11 +3,6 @@ using legallead.records.search.Classes;
 using legallead.records.search.tests.Mapper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace legallead.records.search.tests
 {

--- a/src/core/legallead.core/tests/legallead.records.search.tests/Web/CollinCountyNavigationTests.cs
+++ b/src/core/legallead.core/tests/legallead.records.search.tests/Web/CollinCountyNavigationTests.cs
@@ -13,11 +13,13 @@ namespace legallead.records.search.Tests
         [AssemblyCleanup]
         public static void AssemblyCleanUp()
         {
-            const string processName = "chromedriver";
-            foreach (var process in Process.GetProcessesByName(processName))
+            const string names = "chromedriver,geckodriver";
+            var processes = names.Split(',').ToList();
+            processes.ForEach(p =>
             {
-                process.Kill();
-            }
+                var items = Process.GetProcessesByName(p).ToList();
+                items.ForEach(i => i.Kill());
+            });
         }
 
         [TestMethod]

--- a/src/db/component/legallead.jdbc/entities/WorkBeginningBo.cs
+++ b/src/db/component/legallead.jdbc/entities/WorkBeginningBo.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace legallead.jdbc.entities
+{
+    public class WorkBeginningBo
+    {
+        [JsonProperty("src")]
+        public string Source { get; set; } = Environment.MachineName;
+        [JsonProperty("ids")]
+        public IEnumerable<WorkIndexBo> WorkIndexes { get; set; } = Enumerable.Empty<WorkIndexBo>();
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/WorkIndexBo.cs
+++ b/src/db/component/legallead.jdbc/entities/WorkIndexBo.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace legallead.jdbc.entities
+{
+    public class WorkIndexBo
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/WorkStatusBo.cs
+++ b/src/db/component/legallead.jdbc/entities/WorkStatusBo.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace legallead.jdbc.entities
+{
+    public class WorkStatusBo
+    {
+        [JsonProperty("src")]
+        public string Source { get; set; } = Environment.MachineName;
+        [JsonProperty("id")]
+        public string Id { get; set; } = string.Empty;
+        [JsonProperty("messageId")]
+        public int MessageId { get; set; }
+        [JsonProperty("statusId")]
+        public int StatusId { get; set; }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/WorkingSearchBo.cs
+++ b/src/db/component/legallead.jdbc/entities/WorkingSearchBo.cs
@@ -1,0 +1,14 @@
+﻿namespace legallead.jdbc.entities
+{
+    public class WorkingSearchBo
+    {
+        public string? Id { get; set; }
+        public string? SearchId { get; set; }
+        public int MessageId { get; set; }
+        public int StatusId { get; set; }
+        public string? MachineName { get; set; }
+        public DateTime CreateDate { get; set; }
+        public DateTime LastUpdateDt { get; set; }
+        public DateTime? CompletionDate { get; set; }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/WorkingSearchDto.cs
+++ b/src/db/component/legallead.jdbc/entities/WorkingSearchDto.cs
@@ -1,0 +1,74 @@
+﻿namespace legallead.jdbc.entities
+{
+    public class WorkingSearchDto : BaseDto
+    {
+        public string? SearchId { get; set; }
+        public int MessageId { get; set; }
+        public int StatusId { get; set; }
+        public string? MachineName { get; set; }
+        public DateTime CreateDate { get; set; }
+        public DateTime LastUpdateDt { get; set; }
+        public DateTime? CompletionDate { get; set; }
+        public override object? this[string field]
+        {
+            get
+            {
+                if (field == null) return null;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return null;
+                if (fieldName.Equals("Id", Comparison)) return Id;
+                if (fieldName.Equals("SearchId", Comparison)) return SearchId;
+                if (fieldName.Equals("MessageId", Comparison)) return MessageId;
+                if (fieldName.Equals("StatusId", Comparison)) return StatusId;
+                if (fieldName.Equals("MachineName", Comparison)) return MachineName;
+                if (fieldName.Equals("CreateDate", Comparison)) return CreateDate;
+                if (fieldName.Equals("LastUpdateDt", Comparison)) return LastUpdateDt;
+                return CompletionDate;
+            }
+
+            set
+            {
+                if (field == null) return;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return;
+                if (fieldName.Equals("Id", Comparison))
+                {
+                    Id = ChangeType<string>(value) ?? string.Empty;
+                    return;
+                }
+                if (fieldName.Equals("SearchId", Comparison))
+                {
+                    SearchId = ChangeType<string>(value);
+                    return;
+                }
+                if (fieldName.Equals("MessageId", Comparison))
+                {
+                    MessageId = ChangeType<int>(value);
+                    return;
+                }
+                if (fieldName.Equals("StatusId", Comparison))
+                {
+                    StatusId = ChangeType<int>(value);
+                    return;
+                }
+                if (fieldName.Equals("MachineName", Comparison))
+                {
+                    MachineName = ChangeType<string>(value);
+                    return;
+                }
+                if (fieldName.Equals("CreateDate", Comparison))
+                {
+                    CreateDate = ChangeType<DateTime>(value);
+                }
+                if (fieldName.Equals("LastUpdateDt", Comparison))
+                {
+                    LastUpdateDt = ChangeType<DateTime>(value);
+                }
+                if (fieldName.Equals("CompletionDate", Comparison))
+                {
+                    CompletionDate = ChangeType<DateTime?>(value);
+                }
+            }
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/implementations/SearchStatusRepository.cs
+++ b/src/db/component/legallead.jdbc/implementations/SearchStatusRepository.cs
@@ -1,0 +1,83 @@
+﻿using Dapper;
+using legallead.jdbc.entities;
+using legallead.jdbc.helpers;
+using legallead.jdbc.interfaces;
+using Newtonsoft.Json;
+
+namespace legallead.jdbc.implementations
+{
+    public class SearchStatusRepository : BaseRepository<SearchDto>, ISearchStatusRepository
+    {
+        public SearchStatusRepository(DataContext context) : base(context)
+        {
+        }
+
+        public bool Begin(WorkBeginningBo bo)
+        {
+            try
+            {
+                var prc = Procs[ProcedureNames.Begin];
+                var parm = new DynamicParameters();
+                parm.Add("js", JsonConvert.SerializeObject(bo));
+                using var connection = _context.CreateConnection();
+                _command.ExecuteAsync(connection, prc, parm).GetAwaiter().GetResult();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+        public bool Update(WorkStatusBo bo)
+        {
+            try
+            {
+                var prc = Procs[ProcedureNames.Status];
+                var parm = new DynamicParameters();
+                parm.Add("js", JsonConvert.SerializeObject(bo));
+                using var connection = _context.CreateConnection();
+                _command.ExecuteAsync(connection, prc, parm).GetAwaiter().GetResult();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+        public IEnumerable<WorkingSearchBo>? List()
+        {
+            try
+            {
+                var prc = Procs[ProcedureNames.All];
+                using var connection = _context.CreateConnection();
+                var list = _command.QueryAsync<WorkingSearchDto>(connection, prc).GetAwaiter().GetResult();
+                if (list == null) return null;
+                return TranslateTo<List<WorkingSearchBo>>(list);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        private static T TranslateTo<T>(object source) where T : class, new()
+        {
+
+            var tmp = JsonConvert.SerializeObject(source);
+            return JsonConvert.DeserializeObject<T>(tmp) ?? new();
+        }
+
+        private static readonly Dictionary<ProcedureNames, string> Procs = new(){
+            { ProcedureNames.All, "CALL USP_WORKTABLE_ALL();" },
+            { ProcedureNames.Begin, "CALL USP_WORKTABLE_BEGIN( ? );" },
+            { ProcedureNames.Status, "CALL USP_WORKTABLE_STATUS( ? );" },
+            };
+
+        private enum ProcedureNames
+        {
+            All = 0,
+            Begin = 1,
+            Status = 2
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/interfaces/ISearchStatusRepository.cs
+++ b/src/db/component/legallead.jdbc/interfaces/ISearchStatusRepository.cs
@@ -1,0 +1,11 @@
+﻿using legallead.jdbc.entities;
+
+namespace legallead.jdbc.interfaces
+{
+    public interface ISearchStatusRepository
+    {
+        bool Begin(WorkBeginningBo bo);
+        bool Update(WorkStatusBo bo);
+        IEnumerable<WorkingSearchBo>? List();
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/BtoDtoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/BtoDtoTests.cs
@@ -47,12 +47,16 @@ namespace legallead.jdbc.tests
         private static IEnumerable<Type>? types;
         private static IEnumerable<Type> GetDtoTypes()
         {
-            var type = typeof(BaseDto);
-            return AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(s => s.GetTypes())
-                .Where(p => type.IsAssignableFrom(p))
-                .Where(i => !i.IsInterface)
-                .Where(a => !a.IsAbstract);
+            lock (_sync)
+            {
+                var type = typeof(BaseDto);
+                return AppDomain.CurrentDomain.GetAssemblies()
+                    .SelectMany(s => s.GetTypes())
+                    .Where(p => type.IsAssignableFrom(p))
+                    .Where(i => !i.IsInterface)
+                    .Where(a => !a.IsAbstract); 
+            }
         }
+        private static readonly object _sync = new();
     }
 }

--- a/src/db/tests/legallead.jdbc.tests/entities/WorkBeginningBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/WorkBeginningBoTests.cs
@@ -1,0 +1,73 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class WorkBeginningBoTests
+    {
+
+
+        private static readonly Faker<WorkIndexBo> idfaker =
+            new Faker<WorkIndexBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"));
+
+        private static readonly Faker<WorkBeginningBo> faker =
+            new Faker<WorkBeginningBo>()
+            .RuleFor(x => x.WorkIndexes, y =>
+            {
+                var n = y.Random.Int(1, 8);
+                return idfaker.Generate(n);
+            });
+
+        [Fact]
+        public void WorkBeginningBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                var tmp = new WorkBeginningBo();
+                Assert.False(string.IsNullOrWhiteSpace(tmp.Source));
+                Assert.Empty(tmp.WorkIndexes);
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkBeginningBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkBeginningBoCanGetSource()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.Equal(src.Source, dest.Source);
+        }
+
+        [Fact]
+        public void WorkBeginningBoCanSetSource()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            src.Source = dest.Source;
+            Assert.Equal(src.Source, dest.Source);
+        }
+
+        [Fact]
+        public void WorkBeginningBoCanSetWorkIndexes()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            src.WorkIndexes = dest.WorkIndexes;
+            Assert.Equal(src.WorkIndexes, dest.WorkIndexes);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/WorkIndexBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/WorkIndexBoTests.cs
@@ -1,0 +1,45 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class WorkIndexBoTests
+    {
+
+
+        private static readonly Faker<WorkIndexBo> faker =
+            new Faker<WorkIndexBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"));
+
+
+        [Fact]
+        public void WorkIndexBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new WorkIndexBo();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkIndexBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkIndexBoCanSetId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.Id = src.Id;
+            Assert.Equal(src.Id, dest.Id);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/WorkStatusBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/WorkStatusBoTests.cs
@@ -1,0 +1,78 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class WorkStatusBoTests
+    {
+
+
+        private static readonly Faker<WorkStatusBo> faker =
+            new Faker<WorkStatusBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.MessageId, y => y.Random.Int(0, 6))
+            .RuleFor(x => x.StatusId, y => y.Random.Int(0, 2));
+
+
+        [Fact]
+        public void WorkStatusBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                var tmp = new WorkStatusBo();
+                Assert.False(string.IsNullOrEmpty(tmp.Source));
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkStatusBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkStatusBoCanSetId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.Id = src.Id;
+            Assert.Equal(src.Id, dest.Id);
+        }
+
+        [Fact]
+        public void WorkStatusBoCanSetSource()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.Source = src.Source;
+            Assert.Equal(src.Source, dest.Source);
+        }
+
+        [Fact]
+        public void WorkStatusBoCanSetMessageId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.MessageId = src.MessageId;
+            Assert.Equal(src.MessageId, dest.MessageId);
+        }
+
+        [Fact]
+        public void WorkStatusBoCanSetStatusId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.StatusId = src.StatusId;
+            Assert.Equal(src.StatusId, dest.StatusId);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/WorkingSearchBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/WorkingSearchBoTests.cs
@@ -1,0 +1,122 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class WorkingSearchBoTests
+    {
+
+
+        private static readonly Faker<WorkingSearchBo> faker =
+            new Faker<WorkingSearchBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.SearchId, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.MessageId, y => y.Random.Int(0, 6))
+            .RuleFor(x => x.StatusId, y => y.Random.Int(0, 2))
+            .RuleFor(x => x.MachineName, y => y.Hacker.Phrase())
+            .RuleFor(x => x.CreateDate, y => y.Date.Recent())
+            .RuleFor(x => x.LastUpdateDt, y => y.Date.Recent())
+            .RuleFor(x => x.CompletionDate, y => y.Date.Recent());
+
+
+        [Fact]
+        public void WorkingSearchBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new WorkingSearchBo();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.Id = src.Id;
+            Assert.Equal(src.Id, dest.Id);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetSearchId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.SearchId = src.SearchId;
+            Assert.Equal(src.SearchId, dest.SearchId);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetMessageId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.MessageId = src.MessageId;
+            Assert.Equal(src.MessageId, dest.MessageId);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetStatusId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.StatusId = src.StatusId;
+            Assert.Equal(src.StatusId, dest.StatusId);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetMachineName()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.MachineName = src.MachineName;
+            Assert.Equal(src.MachineName, dest.MachineName);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetCreateDate()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.CreateDate = src.CreateDate;
+            Assert.Equal(src.CreateDate, dest.CreateDate);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetLastUpdateDt()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.LastUpdateDt = src.LastUpdateDt;
+            Assert.Equal(src.LastUpdateDt, dest.LastUpdateDt);
+        }
+
+        [Fact]
+        public void WorkingSearchBoCanSetCompletionDate()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            dest.CompletionDate = src.CompletionDate;
+            Assert.Equal(src.CompletionDate, dest.CompletionDate);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/WorkingSearchDtoTest.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/WorkingSearchDtoTest.cs
@@ -1,0 +1,84 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class WorkingSearchDtoTests
+    {
+
+        private static readonly Faker<WorkingSearchDto> faker =
+            new Faker<WorkingSearchDto>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.SearchId, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.MessageId, y => y.Random.Int(0, 6))
+            .RuleFor(x => x.StatusId, y => y.Random.Int(0, 2))
+            .RuleFor(x => x.MachineName, y => y.Hacker.Phrase())
+            .RuleFor(x => x.CreateDate, y => y.Date.Recent())
+            .RuleFor(x => x.LastUpdateDt, y => y.Date.Recent())
+            .RuleFor(x => x.CompletionDate, y => y.Date.Recent());
+
+
+
+        [Fact]
+        public void WorkingSearchDtoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new WorkingSearchDto();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void WorkingSearchDtoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("SearchId")]
+        [InlineData("MessageId")]
+        [InlineData("StatusId")]
+        [InlineData("MachineName")]
+        [InlineData("CreateDate")]
+        [InlineData("LastUpdateDt")]
+        [InlineData("CompletionDate")]
+        public void WorkingSearchDtoHasExpectedFieldDefined(string name)
+        {
+            const string na = "notmapped";
+            var sut = new WorkingSearchDto();
+            var fields = sut.FieldList;
+            sut[na] = na;
+            _ = sut[na];
+            Assert.NotNull(fields);
+            Assert.NotEmpty(fields);
+            Assert.Contains(name, fields);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("SearchId")]
+        [InlineData("MessageId")]
+        [InlineData("StatusId")]
+        [InlineData("MachineName")]
+        [InlineData("CreateDate")]
+        [InlineData("LastUpdateDt")]
+        [InlineData("CompletionDate")]
+        public void WorkingSearchDtoCanReadWriteByIndex(string fieldName)
+        {
+            var demo = faker.Generate();
+            var sut = new WorkingSearchDto();
+            var flds = sut.FieldList;
+            demo["id"] = null;
+            var position = flds.IndexOf(fieldName);
+            sut[position] = demo[position];
+            var actual = sut[position];
+            Assert.Equal(demo[position], actual);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/implementations/SearchStatusRepositoryTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/implementations/SearchStatusRepositoryTests.cs
@@ -1,0 +1,182 @@
+﻿using Bogus;
+using Dapper;
+using legallead.jdbc.entities;
+using legallead.jdbc.helpers;
+using legallead.jdbc.implementations;
+using legallead.jdbc.interfaces;
+using Moq;
+using System.Data;
+
+namespace legallead.jdbc.tests.implementations
+{
+    public class SearchStatusRepositoryTests
+    {
+
+        private static readonly Faker<WorkIndexBo> idfaker =
+            new Faker<WorkIndexBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"));
+
+        private static readonly Faker<WorkBeginningBo> beginfaker =
+            new Faker<WorkBeginningBo>()
+            .RuleFor(x => x.WorkIndexes, y =>
+            {
+                var n = y.Random.Int(1, 8);
+                return idfaker.Generate(n);
+            });
+        private static readonly Faker<WorkStatusBo> statusfaker =
+            new Faker<WorkStatusBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.MessageId, y => y.Random.Int(0, 6))
+            .RuleFor(x => x.StatusId, y => y.Random.Int(0, 2));
+
+        private static readonly Faker<WorkingSearchDto> dtofaker =
+            new Faker<WorkingSearchDto>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.SearchId, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.MessageId, y => y.Random.Int(0, 6))
+            .RuleFor(x => x.StatusId, y => y.Random.Int(0, 2))
+            .RuleFor(x => x.MachineName, y => y.Hacker.Phrase())
+            .RuleFor(x => x.CreateDate, y => y.Date.Recent())
+            .RuleFor(x => x.LastUpdateDt, y => y.Date.Recent())
+            .RuleFor(x => x.CompletionDate, y => y.Date.Recent());
+
+        private static readonly Faker faker = new();
+        [Fact]
+        public void RepoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                var container = new RepoContainer();
+                Assert.NotNull(container.Repo);
+            });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData(false, 5)]
+        [InlineData(false, 10)]
+        [InlineData(true, 10)]
+        public void RepoCanBegin(bool hasException, int recordCount)
+        {
+            var request = beginfaker.Generate(recordCount);
+            var exception = faker.System.Exception();
+            var container = new RepoContainer();
+            var service = container.Repo;
+            var mock = container.CommandMock;
+            if (hasException)
+            {
+                mock.Setup(m => m.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(exception);
+            }
+            else
+            {
+                mock.Setup(m => m.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).Verifiable();
+            }
+            _ = service.Begin(request[0]);
+            mock.Verify(m => m.ExecuteAsync(
+                It.IsAny<IDbConnection>(),
+                It.IsAny<string>(),
+                It.IsAny<DynamicParameters>()));
+        }
+        [Theory]
+        [InlineData(false, 5)]
+        [InlineData(false, 10)]
+        [InlineData(true, 10)]
+        public void RepoCanUpdate(bool hasException, int recordCount)
+        {
+            var request = statusfaker.Generate(recordCount);
+            var exception = faker.System.Exception();
+            var container = new RepoContainer();
+            var service = container.Repo;
+            var mock = container.CommandMock;
+            if (hasException)
+            {
+                mock.Setup(m => m.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(exception);
+            }
+            else
+            {
+                mock.Setup(m => m.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).Verifiable();
+            }
+            _ = service.Update(request[0]);
+            mock.Verify(m => m.ExecuteAsync(
+                It.IsAny<IDbConnection>(),
+                It.IsAny<string>(),
+                It.IsAny<DynamicParameters>()));
+        }
+
+        [Theory]
+        [InlineData(false, 0)]
+        [InlineData(false, 5)]
+        [InlineData(false, 10)]
+        [InlineData(true, 10)]
+        public void RepoCanList(bool hasException, int recordCount)
+        {
+            var response = recordCount switch
+            {
+                0 => null,
+                _ => dtofaker.Generate(recordCount)
+            };
+            var exception = faker.System.Exception();
+            var container = new RepoContainer();
+            var service = container.Repo;
+            var mock = container.CommandMock;
+            if (hasException)
+            {
+                mock.Setup(m => m.QueryAsync<WorkingSearchDto>(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(exception);
+            }
+            else
+            {
+                mock.Setup(m => m.QueryAsync<WorkingSearchDto>(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ReturnsAsync(response);
+            }
+            _ = service.List();
+            mock.Verify(m => m.QueryAsync<WorkingSearchDto>(
+                It.IsAny<IDbConnection>(),
+                It.IsAny<string>(),
+                It.IsAny<DynamicParameters>()));
+        }
+        private sealed class RepoContainer
+        {
+            private readonly SearchStatusRepository repo;
+            private readonly Mock<IDapperCommand> command;
+            public RepoContainer()
+            {
+                command = new Mock<IDapperCommand>();
+                var dataContext = new MockDataContext(command.Object);
+                repo = new SearchStatusRepository(dataContext);
+            }
+
+            public SearchStatusRepository Repo => repo;
+            public Mock<IDapperCommand> CommandMock => command;
+
+        }
+        private sealed class MockDataContext : DataContext
+        {
+            public MockDataContext(IDapperCommand command) : base(command)
+            {
+            }
+
+            public override IDbConnection CreateConnection()
+            {
+                var mock = new Mock<IDbConnection>();
+                return mock.Object;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem:
In order to prevent multiple workers from processing a user search request,
database control can be added to filter search requests that are already being handled.

### Implementation:
- added bo/dto objects to store user search progresses
- added repository to perform CRUD operations against the working-search table