### PR TITLE
PR | CORE | Add method to get email by search id

### DIFF
--- a/src/db/component/legallead.jdbc/entities/QueueWorkingUserBo.cs
+++ b/src/db/component/legallead.jdbc/entities/QueueWorkingUserBo.cs
@@ -1,0 +1,9 @@
+﻿namespace legallead.jdbc.entities
+{
+    public class QueueWorkingUserBo
+    {
+        public string? Id { get; set; }
+        public string? UserName { get; set; }
+        public string? Email { get; set; }
+    }
+}

--- a/src/db/component/legallead.jdbc/implementations/QueueWorkRepository.cs
+++ b/src/db/component/legallead.jdbc/implementations/QueueWorkRepository.cs
@@ -72,6 +72,26 @@ namespace legallead.jdbc.implementations
             }
         }
 
+        public QueueWorkingUserBo? GetUserBySearchId(string? searchId)
+        {
+            if (string.IsNullOrEmpty(searchId)) return null;
+            if (!Guid.TryParse(searchId, out var _)) return null;
+            try
+            {
+                var prc = Procs[ProcedureNames.Insert];
+                var parms = new DynamicParameters();
+                parms.Add("search_index", searchId);
+                using var connection = _context.CreateConnection();
+                var list = _command.QueryAsync<CustomerDto>(connection, prc, parms).GetAwaiter().GetResult();
+                if (list == null || !list.Any()) return new();
+                return TranslateTo<QueueWorkingUserBo>(list.First());
+            }
+            catch (Exception)
+            {
+                return new();
+            }
+        }
+
         private static T TranslateTo<T>(object source) where T : class, new()
         {
 
@@ -83,13 +103,15 @@ namespace legallead.jdbc.implementations
             { ProcedureNames.Insert, "CALL USP_INSERT_QUEUEWORKING( ? );" },
             { ProcedureNames.Update, "CALL USP_UPDATE_QUEUEWORKING( ? );" },
             { ProcedureNames.Fetch, "CALL USP_FETCH_QUEUEWORKING();" },
+            { ProcedureNames.GetUser, "CALL USP_FETCH_ACCOUNT_BY_SEARCH_INDEX( ? );" },
             };
 
         private enum ProcedureNames
         {
             Insert = 0,
             Update = 1,
-            Fetch = 2
+            Fetch = 2,
+            GetUser = 3
         }
     }
 }

--- a/src/db/component/legallead.jdbc/interfaces/IQueueWorkRepository.cs
+++ b/src/db/component/legallead.jdbc/interfaces/IQueueWorkRepository.cs
@@ -7,5 +7,6 @@ namespace legallead.jdbc.interfaces
         List<QueueWorkingBo> InsertRange(string json);
         QueueWorkingBo? UpdateStatus(QueueWorkingBo updateBo);
         List<QueueWorkingBo> Fetch();
+        QueueWorkingUserBo? GetUserBySearchId(string? searchId);
     }
 }

--- a/src/db/tests/legallead.jdbc.tests/BtoDtoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/BtoDtoTests.cs
@@ -63,12 +63,19 @@ namespace legallead.jdbc.tests
         {
             lock (_sync)
             {
-                var type = typeof(BaseDto);
-                return AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(s => s.GetTypes())
-                    .Where(p => type.IsAssignableFrom(p))
-                    .Where(i => !i.IsInterface)
-                    .Where(a => !a.IsAbstract);
+                try
+                {
+                    var type = typeof(BaseDto);
+                    return AppDomain.CurrentDomain.GetAssemblies()
+                        .SelectMany(s => s.GetTypes())
+                        .Where(p => type.IsAssignableFrom(p))
+                        .Where(i => !i.IsInterface)
+                        .Where(a => !a.IsAbstract);
+                }
+                catch (Exception)
+                {
+                    return Enumerable.Empty<Type>();
+                }
             }
         }
         private static readonly object _sync = new();

--- a/src/db/tests/legallead.jdbc.tests/entities/QueueWorkingUserBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/QueueWorkingUserBoTests.cs
@@ -1,0 +1,63 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class QueueWorkingUserBoTests
+    {
+
+
+        private static readonly Faker<QueueWorkingUserBo> faker =
+            new Faker<QueueWorkingUserBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.UserName, y => y.Person.UserName)
+            .RuleFor(x => x.Email, y => y.Person.Email);
+
+        [Fact]
+        public void QueueWorkingUserBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new QueueWorkingUserBo();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void QueueWorkingUserBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void QueueWorkingUserBoCanGetId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Id, dest.Id);
+        }
+
+        [Fact]
+        public void QueueWorkingUserBoCanGetUserName()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.UserName, dest.UserName);
+        }
+
+        [Fact]
+        public void QueueWorkingUserBoCanGetEmail()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Email, dest.Email);
+        }
+    }
+}


### PR DESCRIPTION
## Discussion   
As an api, I want to fetch the email address associated to a search request so that I can notify the user that their search request has been completed.

## Details
- create business object for customer detail
- add new repository method to fetch user by search id
- add unit test coverage