### PR TITLE
PR | Core | Setup Windows Firefox Profile

### DIFF
--- a/src/core/legallead.core/component/records.search/DriverFactory/FireFoxProvider.cs
+++ b/src/core/legallead.core/component/records.search/DriverFactory/FireFoxProvider.cs
@@ -37,6 +37,8 @@ namespace legallead.records.search.DriverFactory
                 var isWindows = IsWindows();
                 if (!isWindows) return GetLinuxDriver();
                 var profile = new FirefoxOptions();
+                profile.AddArguments("--headless");
+                profile.AddAdditionalCapability("video", "True", true);
                 profile.SetPreference("browser.safebrowsing.enabled", true);
                 profile.SetPreference("browser.safebrowsing.malware.enabled", true);
                 profile.UnhandledPromptBehavior = UnhandledPromptBehavior.Accept;


### PR DESCRIPTION
fix: firefox driver set headless
- adding attribute to firefox options to hide browser window