### PR TITLE
PR | Core | Driver Service

### DIFF
--- a/.github/workflows/dotnet-presentation-core-package.yml
+++ b/.github/workflows/dotnet-presentation-core-package.yml
@@ -15,6 +15,7 @@ jobs:
   release:
     permissions: write-all
     runs-on: windows-latest
+    environment: core
     
 
     steps:

--- a/src/core/legallead.core/component/records.search/DriverFactory/FireFoxProvider.cs
+++ b/src/core/legallead.core/component/records.search/DriverFactory/FireFoxProvider.cs
@@ -109,16 +109,18 @@ namespace legallead.records.search.DriverFactory
 
             private static FirefoxOptions GetOptions(int mode, string downloadDir)
             {
+                var sourceDir = _knownPaths[1];
+                var targetDir = _knownPaths[3];
+                LinuxConfiguration.Copy(sourceDir, targetDir);
                 var locations = _knownPaths.FindAll(x => Directory.Exists(x));
                 locations.ForEach(name => AppendToPath(name));
-
                 var profile = new FirefoxOptions();
                 if (mode == 0)
                 {
                     var binaryFile = GetBinaryFileName();
                     profile.BrowserExecutableLocation = binaryFile;
                 }
-
+                
                 profile.AddArguments("-headless");
                 profile.AddArguments("--headless");
                 profile.AddAdditionalCapability("platform", "LINUX", true);
@@ -131,11 +133,12 @@ namespace legallead.records.search.DriverFactory
             }
             private static FirefoxDriver GetDriver(int mode)
             {
+                var service = FirefoxDriverService.CreateDefaultService(_knownPaths[3], "geckodriver");
                 var options = GetOptions(mode, GetDriverDirectoryName());
                 var driver = mode switch
                 {
                     0 => new FirefoxDriver(GetDriverDirectoryName(), options),
-                    1 => new FirefoxDriver(options),
+                    1 => new FirefoxDriver(service, options),
                     _ => new FirefoxDriver()
                 };
                 return driver;
@@ -186,7 +189,8 @@ namespace legallead.records.search.DriverFactory
             private static readonly List<string> _knownPaths = new() {
                 "/var/app/current",
                 "/var/app/current/geckodriver",
-                "/home/webapp/.local/share"
+                "/home/webapp/.local/share",
+                "/home/webapp/.local/share/geckodriver"
             };
         }
 

--- a/src/core/legallead.core/component/records.search/DriverFactory/LinuxConfiguration.cs
+++ b/src/core/legallead.core/component/records.search/DriverFactory/LinuxConfiguration.cs
@@ -1,0 +1,36 @@
+﻿namespace legallead.records.search.DriverFactory
+{
+    internal static class LinuxConfiguration
+    {
+
+        public static void Copy(string sourceDirectory, string targetDirectory)
+        {
+            if (!Directory.Exists(sourceDirectory)) return;
+            if (Directory.Exists(targetDirectory)) return;
+            var diSource = new DirectoryInfo(sourceDirectory);
+            var diTarget = new DirectoryInfo(targetDirectory);
+
+            CopyAll(diSource, diTarget);
+        }
+
+        public static void CopyAll(DirectoryInfo source, DirectoryInfo target)
+        {
+            Directory.CreateDirectory(target.FullName);
+
+            // Copy each file into the new directory.
+            foreach (FileInfo fi in source.GetFiles())
+            {
+                Console.WriteLine(@"Copying {0}\{1}", target.FullName, fi.Name);
+                fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
+            }
+
+            // Copy each subdirectory using recursion.
+            foreach (DirectoryInfo diSourceSubDir in source.GetDirectories())
+            {
+                DirectoryInfo nextTargetSubDir =
+                    target.CreateSubdirectory(diSourceSubDir.Name);
+                CopyAll(diSourceSubDir, nextTargetSubDir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Context
During system test, web drivers are unable to execute with error message:

```
An error occurred trying to start process '../geckodriver' with working directory '../current'. 
Permission denied
```

### Correction
- change to drive create process to use a driver service mapped to home directory.