### PR TITLE
PR | Core | Add Status To Queue Services

### DIFF
--- a/src/core/legallead.core/tests/legallead.records.search.tests/HarrisJpIntegrationTest.cs
+++ b/src/core/legallead.core/tests/legallead.records.search.tests/HarrisJpIntegrationTest.cs
@@ -39,17 +39,21 @@ namespace legallead.records.search.tests.Web
 
         [TestMethod]
         [TestCategory("harris.jp.county.actions")]
-        public void CanGetFromJsonInteractive()
+        [DataRow("a")]
+        [DataRow("0")]
+        [DataRow("1")]
+        [DataRow("2")]
+        public void CanGetFromJsonInteractive(string courtIndex = "0")
         {
             if (!Debugger.IsAttached) return;
-            var interactive = GetHarrisJpInteractive();
+            var interactive = GetHarrisJpInteractive(courtIndex);
             var result = interactive.Fetch();
             Assert.IsNotNull(result);
             Assert.IsNotNull(result.PeopleList);
             Assert.IsTrue(result.PeopleList.Any());
         }
 
-        private static MockHarrisJpWeb GetHarrisJpInteractive()
+        private static MockHarrisJpWeb GetHarrisJpInteractive(string courtIndex = "0")
         {
 
             DayOfWeek[] weekends = new[] { DayOfWeek.Sunday, DayOfWeek.Saturday };
@@ -61,7 +65,7 @@ namespace legallead.records.search.tests.Web
             var webParameter = BaseWebIneractive.GetWebNavigation(HarrisJpId, dte, dte);
             var custom = new List<WebNavigationKey>
             {
-                new () { Name = "courtIndex", Value = "0" },
+                new () { Name = "courtIndex", Value = courtIndex },
                 new () { Name = "caseStatusIndex", Value = "0" }
             };
             custom.ForEach(x => { AddOrUpdateKey(webParameter.Keys, x); });

--- a/src/db/component/legallead.jdbc/entities/StatusDto.cs
+++ b/src/db/component/legallead.jdbc/entities/StatusDto.cs
@@ -1,0 +1,39 @@
+﻿namespace legallead.jdbc.entities
+{
+    [TargetTable(TableName = "SearchProgress")]
+    public class StatusDto : BaseDto
+    {
+        public string? SearchProgress { get; set; }
+        public int? Total { get; set; }
+
+        public override object? this[string field]
+        {
+            get
+            {
+                if (field == null) return null;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return null;
+                if (fieldName.Equals("Id", Comparison)) return Id;
+                if (fieldName.Equals("SearchProgress", Comparison)) return SearchProgress;
+                return Total;
+            }
+            set
+            {
+                if (field == null) return;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return;
+                if (fieldName.Equals("Id", Comparison))
+                {
+                    Id = ChangeType<string>(value) ?? string.Empty;
+                    return;
+                }
+                if (fieldName.Equals("SearchProgress", Comparison))
+                {
+                    SearchProgress = ChangeType<string>(value) ?? string.Empty;
+                    return;
+                }
+                if (fieldName.Equals("Total", Comparison)) Total = ChangeType<int?>(value);
+            }
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/StatusSummaryBo.cs
+++ b/src/db/component/legallead.jdbc/entities/StatusSummaryBo.cs
@@ -1,0 +1,8 @@
+﻿namespace legallead.jdbc.entities
+{
+    public class StatusSummaryBo
+    {
+        public string? SearchProgress { get; set; }
+        public int? Total { get; set; }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/StatusSummaryByCountyBo.cs
+++ b/src/db/component/legallead.jdbc/entities/StatusSummaryByCountyBo.cs
@@ -1,0 +1,10 @@
+﻿namespace legallead.jdbc.entities
+{
+    public class StatusSummaryByCountyBo
+    {
+        public string? Region { get; set; }
+        public int? Count { get; set; }
+        public DateTime? Oldest { get; set; }
+        public DateTime? Newest { get; set; }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/StatusSummaryDto.cs
+++ b/src/db/component/legallead.jdbc/entities/StatusSummaryDto.cs
@@ -1,0 +1,53 @@
+﻿namespace legallead.jdbc.entities
+{
+    [TargetTable(TableName = "StatusSummary")]
+    public class StatusSummaryDto : BaseDto
+    {
+        public string? Region { get; set; }
+        public int? Count { get; set; }
+        public DateTime? Oldest { get; set; }
+        public DateTime? Newest { get; set; }
+
+        public override object? this[string field]
+        {
+            get
+            {
+                if (field == null) return null;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return null;
+                if (fieldName.Equals("Id", Comparison)) return Id;
+                if (fieldName.Equals("Region", Comparison)) return Region;
+                if (fieldName.Equals("Count", Comparison)) return Count;
+                if (fieldName.Equals("Oldest", Comparison)) return Oldest;
+                return Newest;
+            }
+            set
+            {
+                if (field == null) return;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return;
+                if (fieldName.Equals("Id", Comparison))
+                {
+                    Id = ChangeType<string>(value) ?? string.Empty;
+                    return;
+                }
+                if (fieldName.Equals("Region", Comparison))
+                {
+                    Region = ChangeType<string>(value) ?? string.Empty;
+                    return;
+                }
+                if (fieldName.Equals("Count", Comparison))
+                {
+                    Count = ChangeType<int?>(value);
+                    return;
+                }
+                if (fieldName.Equals("Oldest", Comparison))
+                {
+                    Oldest = ChangeType<DateTime?>(value);
+                    return;
+                }
+                if (fieldName.Equals("Newest", Comparison)) Newest = ChangeType<DateTime?>(value);
+            }
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/enumerations/QueueStatusTypes.cs
+++ b/src/db/component/legallead.jdbc/enumerations/QueueStatusTypes.cs
@@ -1,0 +1,9 @@
+﻿namespace legallead.jdbc.enumerations
+{
+    public enum QueueStatusTypes
+    {
+        Error,
+        Submitted,
+        Purchased
+    }
+}

--- a/src/db/component/legallead.jdbc/interfaces/IQueueWorkRepository.cs
+++ b/src/db/component/legallead.jdbc/interfaces/IQueueWorkRepository.cs
@@ -1,4 +1,5 @@
 ﻿using legallead.jdbc.entities;
+using legallead.jdbc.enumerations;
 
 namespace legallead.jdbc.interfaces
 {
@@ -8,5 +9,7 @@ namespace legallead.jdbc.interfaces
         QueueWorkingBo? UpdateStatus(QueueWorkingBo updateBo);
         List<QueueWorkingBo> Fetch();
         QueueWorkingUserBo? GetUserBySearchId(string? searchId);
+        Task<List<StatusSummaryByCountyBo>> GetSummary(QueueStatusTypes statusType);
+        Task<List<StatusSummaryBo>> GetStatus();
     }
 }

--- a/src/db/tests/legallead.jdbc.tests/entities/StatusDtoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/StatusDtoTests.cs
@@ -1,0 +1,69 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class StatusDtoTests
+    {
+
+        private static readonly Faker<StatusDto> faker =
+            new Faker<StatusDto>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.SearchProgress, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.Total, y => y.Random.Int(0, 125000));
+
+
+
+        [Fact]
+        public void StatusDtoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new StatusDto();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void StatusDtoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("SearchProgress")]
+        [InlineData("Total")]
+        public void StatusDtoHasExpectedFieldDefined(string name)
+        {
+            const string na = "notmapped";
+            var sut = new StatusDto();
+            var fields = sut.FieldList;
+            sut[na] = na;
+            _ = sut[na];
+            Assert.NotNull(fields);
+            Assert.NotEmpty(fields);
+            Assert.Contains(name, fields);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("SearchProgress")]
+        [InlineData("Total")]
+        public void StatusDtoCanReadWriteByIndex(string fieldName)
+        {
+            var demo = faker.Generate();
+            var sut = new StatusDto();
+            var flds = sut.FieldList;
+            demo["id"] = null;
+            var position = flds.IndexOf(fieldName);
+            sut[position] = demo[position];
+            var actual = sut[position];
+            Assert.Equal(demo[position], actual);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/StatusSummaryBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/StatusSummaryBoTests.cs
@@ -1,0 +1,54 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class StatusSummaryBoTests
+    {
+
+
+
+        private static readonly Faker<StatusSummaryBo> faker =
+            new Faker<StatusSummaryBo>()
+            .RuleFor(x => x.SearchProgress, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.Total, y => y.Random.Int(0, 125000));
+
+        [Fact]
+        public void StatusSummaryBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new StatusSummaryBo();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void StatusSummaryBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void StatusSummaryBoCanGetSearchProgress()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.SearchProgress, dest.SearchProgress);
+        }
+
+        [Fact]
+        public void StatusSummaryBoCanGetTotal()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Total, dest.Total);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/StatusSummaryByCountyBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/StatusSummaryByCountyBoTests.cs
@@ -1,0 +1,74 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class StatusSummaryByCountyBoTests
+    {
+
+
+
+        private static readonly Faker<StatusSummaryByCountyBo> faker =
+            new Faker<StatusSummaryByCountyBo>()
+            .RuleFor(x => x.Region, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.Count, y => y.Random.Int(0, 125000))
+            .RuleFor(x => x.Oldest, y => y.Date.Recent())
+            .RuleFor(x => x.Newest, y => y.Date.Recent());
+
+        [Fact]
+        public void StatusSummaryByCountyBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new StatusSummaryByCountyBo();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void StatusSummaryByCountyBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void StatusSummaryByCountyBoCanGetRegion()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Region, dest.Region);
+        }
+
+        [Fact]
+        public void StatusSummaryByCountyBoCanGetCount()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Count, dest.Count);
+        }
+
+        [Fact]
+        public void StatusSummaryByCountyBoCanGetOldest()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Oldest, dest.Oldest);
+        }
+
+        [Fact]
+        public void StatusSummaryByCountyBoCanGetNewest()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Newest, dest.Newest);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/StatusSummaryDtoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/StatusSummaryDtoTests.cs
@@ -1,0 +1,75 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class StatusSummaryDtoTests
+    {
+
+        private static readonly Faker<StatusSummaryDto> faker =
+            new Faker<StatusSummaryDto>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.Region, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.Count, y => y.Random.Int(0, 125000))
+            .RuleFor(x => x.Oldest, y => y.Date.Recent())
+            .RuleFor(x => x.Newest, y => y.Date.Recent());
+
+
+
+        [Fact]
+        public void StatusSummaryDtoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new StatusSummaryDto();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void StatusSummaryDtoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("Region")]
+        [InlineData("Count")]
+        [InlineData("Oldest")]
+        [InlineData("Newest")]
+        public void StatusSummaryDtoHasExpectedFieldDefined(string name)
+        {
+            const string na = "notmapped";
+            var sut = new StatusSummaryDto();
+            var fields = sut.FieldList;
+            sut[na] = na;
+            _ = sut[na];
+            Assert.NotNull(fields);
+            Assert.NotEmpty(fields);
+            Assert.Contains(name, fields);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("Region")]
+        [InlineData("Count")]
+        [InlineData("Oldest")]
+        [InlineData("Newest")]
+        public void StatusSummaryDtoCanReadWriteByIndex(string fieldName)
+        {
+            var demo = faker.Generate();
+            var sut = new StatusSummaryDto();
+            var flds = sut.FieldList;
+            demo["id"] = null;
+            var position = flds.IndexOf(fieldName);
+            sut[position] = demo[position];
+            var actual = sut[position];
+            Assert.Equal(demo[position], actual);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/implementations/SearchStatusRepositoryTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/implementations/SearchStatusRepositoryTests.cs
@@ -115,6 +115,8 @@ namespace legallead.jdbc.tests.implementations
                 It.IsAny<DynamicParameters>()));
         }
 
+#pragma warning disable CS8604 // Possible null reference argument.
+
         [Theory]
         [InlineData(false, 0)]
         [InlineData(false, 5)]
@@ -151,6 +153,9 @@ namespace legallead.jdbc.tests.implementations
                 It.IsAny<string>(),
                 It.IsAny<DynamicParameters>()));
         }
+
+#pragma warning restore CS8604 // Possible null reference argument.
+
         private sealed class RepoContainer
         {
             private readonly SearchStatusRepository repo;


### PR DESCRIPTION
## Discussion  
As a service, I want to inform user about the status of search requests so that admin will not need to execute db queries of api calls to know the state of queue processing.

## items
- added method to display search summary