### PR TITLE
PR | Core | Add Procedure to Read Person Data

### DIFF
--- a/mysql/testing/find-item-to-invoice.sql
+++ b/mysql/testing/find-item-to-invoice.sql
@@ -1,0 +1,17 @@
+SET @usrid = (SELECT Id FROM USERS u WHERE `UserName` = 'test.account' LIMIT 1);
+SET @indx = 'b5b9d3fa-6bf4-11ef-99ce-0af7a01f52e9';
+-- CALL USP_QUERY_USER_SEARCH( @usrid );
+DROP TEMPORARY TABLE IF EXISTS tmp_my_search;
+CREATE TEMPORARY TABLE tmp_my_search
+SELECT 
+Id, UserId, ExpectedRows, CreateDate, SearchProgress, 
+StateCode, CountyName, EndDate, StartDate
+FROM VW_SEARCH_STATUS_ALL b
+WHERE b.CountyName != 'N/A'
+AND b.SearchProgress = '3 - Completed'
+AND b.UserId = @usrid
+ORDER BY b.CreateDate DESC;
+
+SELECT *
+  FROM tmp_my_search
+  WHERE Id = @indx;

--- a/src/db/component/legallead.jdbc/entities/QueueNonPersonBo.cs
+++ b/src/db/component/legallead.jdbc/entities/QueueNonPersonBo.cs
@@ -1,0 +1,16 @@
+﻿namespace legallead.jdbc.entities
+{
+    public class QueueNonPersonBo
+    {
+        public string? Id { get; set; }
+        public string? UserId { get; set; }
+        public int? ExpectedRows { get; set; }
+        public string? SearchProgress { get; set; }
+        public string? StateCode { get; set; }
+        public string? CountyName { get; set; }
+        public DateTime? EndDate { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? CreateDate { get; set; }
+        public byte[]? ExcelData { get; set; }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/QueueNonPersonDto.cs
+++ b/src/db/component/legallead.jdbc/entities/QueueNonPersonDto.cs
@@ -1,0 +1,56 @@
+﻿namespace legallead.jdbc.entities
+{
+    [TargetTable(TableName = "QUEUEPERSONS")]
+    public class QueueNonPersonDto : BaseDto
+    {
+        public string? UserId { get; set; }
+        public int? ExpectedRows { get; set; }
+        public string? SearchProgress { get; set; }
+        public string? StateCode { get; set; }
+        public string? CountyName { get; set; }
+        public DateTime? EndDate { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? CreateDate { get; set; }
+        public byte[]? ExcelData { get; set; }
+
+        public override object? this[string field]
+        {
+            get
+            {
+                if (field == null) return null;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return null;
+                if (fieldName.Equals("Id", Comparison)) return Id;
+                if (fieldName.Equals("UserId", Comparison)) return UserId;
+                if (fieldName.Equals("ExpectedRows", Comparison)) return ExpectedRows;
+                if (fieldName.Equals("SearchProgress", Comparison)) return SearchProgress;
+                if (fieldName.Equals("StateCode", Comparison)) return StateCode;
+                if (fieldName.Equals("CountyName", Comparison)) return CountyName;
+                if (fieldName.Equals("EndDate", Comparison)) return EndDate;
+                if (fieldName.Equals("StartDate", Comparison)) return StartDate;
+                if (fieldName.Equals("CreateDate", Comparison)) return CreateDate;
+                return ExcelData;
+            }
+            set
+            {
+                if (field == null) return;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return;
+                if (fieldName.Equals("Id", Comparison))
+                {
+                    Id = ChangeType<string>(value) ?? string.Empty;
+                    return;
+                }
+                if (fieldName.Equals("UserId", Comparison)) { UserId = ChangeType<string>(value); return; }
+                if (fieldName.Equals("ExpectedRows", Comparison)) { ExpectedRows = ChangeType<int?>(value); return; }
+                if (fieldName.Equals("SearchProgress", Comparison)) { SearchProgress = ChangeType<string>(value); return; }
+                if (fieldName.Equals("StateCode", Comparison)) { StateCode = ChangeType<string>(value); return; }
+                if (fieldName.Equals("CountyName", Comparison)) { CountyName = ChangeType<string>(value); return; }
+                if (fieldName.Equals("EndDate", Comparison)) { EndDate = ChangeType<DateTime?>(value); return; }
+                if (fieldName.Equals("StartDate", Comparison)) { StartDate = ChangeType<DateTime?>(value); }
+                if (fieldName.Equals("CreateDate", Comparison)) CreateDate = ChangeType<DateTime?>(value);
+                if (fieldName.Equals("ExcelData", Comparison)) ExcelData = ChangeType<byte[]?>(value);
+            }
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/QueuePersonDataBo.cs
+++ b/src/db/component/legallead.jdbc/entities/QueuePersonDataBo.cs
@@ -1,0 +1,9 @@
+﻿namespace legallead.jdbc.entities
+{
+    public class QueuePersonDataBo
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public byte[] Data { get; set; } = Array.Empty<byte>();
+    }
+}

--- a/src/db/component/legallead.jdbc/interfaces/IQueueWorkRepository.cs
+++ b/src/db/component/legallead.jdbc/interfaces/IQueueWorkRepository.cs
@@ -11,5 +11,7 @@ namespace legallead.jdbc.interfaces
         QueueWorkingUserBo? GetUserBySearchId(string? searchId);
         Task<List<StatusSummaryByCountyBo>> GetSummary(QueueStatusTypes statusType);
         Task<List<StatusSummaryBo>> GetStatus();
+        Task<List<QueueNonPersonBo>> GetNonPersonData();
+        QueuePersonDataBo? UpdatePersonData(QueuePersonDataBo bo);
     }
 }

--- a/src/db/tests/legallead.jdbc.tests/entities/QueueNonPersonBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/QueueNonPersonBoTests.cs
@@ -1,0 +1,137 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+using System.Text;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class QueueNonPersonBoTests
+    {
+        private static readonly Faker<QueueNonPersonBo> faker =
+            new Faker<QueueNonPersonBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.UserId, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.ExpectedRows, y => y.Random.Int(0, 750000))
+            .RuleFor(x => x.SearchProgress, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.StateCode, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.CountyName, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.EndDate, y => y.Date.Recent())
+            .RuleFor(x => x.StartDate, y => y.Date.Recent())
+            .RuleFor(x => x.CreateDate, y => y.Date.Recent())
+            .RuleFor(x => x.ExcelData, y =>
+            {
+                var text = y.Hacker.Phrase();
+                return Encoding.UTF8.GetBytes(text);
+            });
+
+
+        [Fact]
+        public void QueueNonPersonBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new QueueNonPersonBo();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Id, dest.Id);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetUserId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.UserId, dest.UserId);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetExpectedRows()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.ExpectedRows, dest.ExpectedRows);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetSearchProgress()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.SearchProgress, dest.SearchProgress);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetStateCode()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.StateCode, dest.StateCode);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetCountyName()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.CountyName, dest.CountyName);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetEndDate()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.EndDate, dest.EndDate);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetStartDate()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.StartDate, dest.StartDate);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetCreateDate()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.CreateDate, dest.CreateDate);
+        }
+
+        [Fact]
+        public void QueueNonPersonBoCanGetExcelData()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.ExcelData, dest.ExcelData);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/QueueNonPersonDtoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/QueueNonPersonDtoTests.cs
@@ -1,0 +1,96 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+using System.Text;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class QueueNonPersonDtoTests
+    {
+
+        private static readonly Faker<QueueNonPersonDto> faker =
+            new Faker<QueueNonPersonDto>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.UserId, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.ExpectedRows, y => y.Random.Int(0, 750000))
+            .RuleFor(x => x.SearchProgress, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.StateCode, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.CountyName, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.EndDate, y => y.Date.Recent())
+            .RuleFor(x => x.StartDate, y => y.Date.Recent())
+            .RuleFor(x => x.CreateDate, y => y.Date.Recent())
+            .RuleFor(x => x.ExcelData, y =>
+            {
+                var text = y.Hacker.Phrase();
+                return Encoding.UTF8.GetBytes(text);
+            });
+
+
+
+        [Fact]
+        public void QueueNonPersonDtoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new QueueNonPersonDto();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void QueueNonPersonDtoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("UserId")]
+        [InlineData("ExpectedRows")]
+        [InlineData("SearchProgress")]
+        [InlineData("StateCode")]
+        [InlineData("CountyName")]
+        [InlineData("EndDate")]
+        [InlineData("StartDate")]
+        [InlineData("CreateDate")]
+        [InlineData("ExcelData")]
+        public void QueueNonPersonDtoHasExpectedFieldDefined(string name)
+        {
+            const string na = "notmapped";
+            var sut = new QueueNonPersonDto();
+            var fields = sut.FieldList;
+            sut[na] = na;
+            _ = sut[na];
+            Assert.NotNull(fields);
+            Assert.NotEmpty(fields);
+            Assert.Contains(name, fields);
+        }
+
+
+        [Theory]
+        [InlineData("Id")]
+        [InlineData("UserId")]
+        [InlineData("ExpectedRows")]
+        [InlineData("SearchProgress")]
+        [InlineData("StateCode")]
+        [InlineData("CountyName")]
+        [InlineData("EndDate")]
+        [InlineData("StartDate")]
+        [InlineData("CreateDate")]
+        [InlineData("ExcelData")]
+        public void QueueNonPersonDtoCanReadWriteByIndex(string fieldName)
+        {
+            var demo = faker.Generate();
+            var sut = new QueueNonPersonDto();
+            var flds = sut.FieldList;
+            demo["id"] = null;
+            var position = flds.IndexOf(fieldName);
+            sut[position] = demo[position];
+            var actual = sut[position];
+            Assert.Equal(demo[position], actual);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/entities/QueuePersonDataBoTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/entities/QueuePersonDataBoTests.cs
@@ -1,0 +1,67 @@
+﻿using Bogus;
+using legallead.jdbc.entities;
+using System.Text;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class QueuePersonDataBoTests
+    {
+
+        private static readonly Faker<QueuePersonDataBo> faker =
+            new Faker<QueuePersonDataBo>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.Name, y => y.Random.Guid().ToString("D"))
+            .RuleFor(x => x.Data, y =>
+            {
+                var txt = y.Hacker.Phrase();
+                return Encoding.UTF8.GetBytes(txt);
+            });
+
+        [Fact]
+        public void QueuePersonDataBoCanBeCreated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = new QueuePersonDataBo();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void QueuePersonDataBoCanBeGenerated()
+        {
+            var exception = Record.Exception(() =>
+            {
+                _ = faker.Generate();
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        public void QueuePersonDataBoCanGetId()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Id, dest.Id);
+        }
+
+        [Fact]
+        public void QueuePersonDataBoCanGetName()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Name, dest.Name);
+        }
+
+        [Fact]
+        public void QueuePersonDataBoCanGetData()
+        {
+            var data = faker.Generate(2);
+            var src = data[0];
+            var dest = data[1];
+            Assert.NotEqual(src.Data, dest.Data);
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/implementations/SearchQueueRepositoryTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/implementations/SearchQueueRepositoryTests.cs
@@ -51,7 +51,7 @@ namespace legallead.jdbc.tests.implementations
         [InlineData(5, true)]
         public async Task RepoGetQueueItem(int count, bool hasError = false)
         {
-            int[] noexecute = new [] { 1, 2, 3 };
+            int[] noexecute = new[] { 1, 2, 3 };
             var faker = new Faker();
             var error = faker.System.Exception();
             var request = count switch


### PR DESCRIPTION
As an API I want to expose landings to allow a queue process to read and update searches with missing person details.