### PR TITLE
PR | API | Usage limit

### DIFF
--- a/release/legallead.permissions.api.release.json
+++ b/release/legallead.permissions.api.release.json
@@ -1,5 +1,10 @@
 [
 	{
+		"name": "3.2.427.--",
+		"description": "API - authenication - setup usage limits - fix",
+		"date": "2024-11-18 08:30:00"
+	},
+	{
 		"name": "3.2.426.--",
 		"description": "API - authenication - setup usage limits by month",
 		"date": "2024-11-17 20:45:00"

--- a/src/api/legallead.permissions.api/Services/LeadSecurityService.cs
+++ b/src/api/legallead.permissions.api/Services/LeadSecurityService.cs
@@ -26,7 +26,7 @@ namespace legallead.permissions.api.Services
             if (data == null || data.Count == 0) return string.Empty;
             var items = data.Select(d =>
             {
-                return new { d.LeadUserId, d.CountyName, Model = GetDecodedString(MapFrom(d)) };
+                return new { d.LeadUserId, d.CountyName, MonthlyLimit = d.MonthlyUsage, Model = GetDecodedString(MapFrom(d)) };
             });
             return JsonConvert.SerializeObject(items);
         }


### PR DESCRIPTION
## Discussion

As a technical lead,
I want my api response to include the usage limit for each county so that the application can limit the amount of traffic needed to validate a user.

### Details
- When a user completes login, the county-data node will append new attribute containing the monthly-usage.