### PR TITLE
PR | API | Integrate Db History Methods

### DIFF
--- a/release/legallead.permissions.api.release.json
+++ b/release/legallead.permissions.api.release.json
@@ -1,5 +1,10 @@
 [
 	{
+		"name": "3.2.433.--",
+		"description": "API - expose method to read/write search to db",
+		"date": "2024-12-07 13:45:00"
+	},
+	{
 		"name": "3.2.432.--",
 		"description": "API - deserialize upload service - fix",
 		"date": "2024-12-05 19:45:00"

--- a/src/api/legallead.permissions.api/Controllers/AppController.cs
+++ b/src/api/legallead.permissions.api/Controllers/AppController.cs
@@ -1,5 +1,4 @@
-﻿using legallead.jdbc.implementations;
-using legallead.jdbc.interfaces;
+﻿using legallead.jdbc.interfaces;
 using legallead.json.db;
 using legallead.json.db.entity;
 using legallead.permissions.api.Entities;

--- a/src/api/legallead.permissions.api/Controllers/DbController.cs
+++ b/src/api/legallead.permissions.api/Controllers/DbController.cs
@@ -1,0 +1,74 @@
+using legallead.permissions.api.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace legallead.permissions.api.Controllers
+{
+    [Route("/db")]
+    [ApiController]
+    public class DbController(
+    ILeadAuthenicationService lead) : ControllerBase
+    {
+        private readonly ILeadAuthenicationService _leadService = lead;
+
+        [HttpPost("begin")]
+        public async Task<IActionResult> BeginAsync(BeginDataRequest model)
+        {
+            try
+            {
+                var user = _leadService.GetUserModel(Request, UserAccountAccess);
+                if (user == null) return Unauthorized();
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return UnprocessableEntity(ex.Message);
+            }
+        }
+
+        [HttpPost("complete")]
+        public async Task<IActionResult> CompleteAsync(CompleteDataRequest model)
+        {
+            try
+            {
+                var user = _leadService.GetUserModel(Request, UserAccountAccess);
+                if (user == null) return Unauthorized();
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return UnprocessableEntity(ex.Message);
+            }
+        }
+        [HttpPost("find")]
+        public async Task<IActionResult> FindAsync(FindDataRequest model)
+        {
+            try
+            {
+                var user = _leadService.GetUserModel(Request, UserAccountAccess);
+                if (user == null) return Unauthorized();
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return UnprocessableEntity(ex.Message);
+            }
+        }
+
+        [HttpPost("upload")]
+        public async Task<IActionResult> UploadAsync(UploadDataRequest model)
+        {
+            try
+            {
+                var user = _leadService.GetUserModel(Request, UserAccountAccess);
+                if (user == null) return Unauthorized();
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return UnprocessableEntity(ex.Message);
+            }
+        }
+        private const string UserAccountAccess = "user account access credential";
+
+    }
+}

--- a/src/api/legallead.permissions.api/Controllers/DbController.cs
+++ b/src/api/legallead.permissions.api/Controllers/DbController.cs
@@ -6,10 +6,11 @@ namespace legallead.permissions.api.Controllers
     [Route("/db")]
     [ApiController]
     public class DbController(
-    ILeadAuthenicationService lead) : ControllerBase
+    ILeadAuthenicationService lead,
+    IDbHistoryService db) : ControllerBase
     {
         private readonly ILeadAuthenicationService _leadService = lead;
-
+        private readonly IDbHistoryService _dataService = db;
         [HttpPost("begin")]
         public async Task<IActionResult> BeginAsync(BeginDataRequest model)
         {
@@ -17,7 +18,8 @@ namespace legallead.permissions.api.Controllers
             {
                 var user = _leadService.GetUserModel(Request, UserAccountAccess);
                 if (user == null) return Unauthorized();
-                return Ok();
+                var response = await _dataService.BeginAsync(model);
+                return Ok(response);
             }
             catch (Exception ex)
             {
@@ -32,7 +34,8 @@ namespace legallead.permissions.api.Controllers
             {
                 var user = _leadService.GetUserModel(Request, UserAccountAccess);
                 if (user == null) return Unauthorized();
-                return Ok();
+                var response = await _dataService.CompleteAsync(model);
+                return Ok(response);
             }
             catch (Exception ex)
             {
@@ -46,7 +49,8 @@ namespace legallead.permissions.api.Controllers
             {
                 var user = _leadService.GetUserModel(Request, UserAccountAccess);
                 if (user == null) return Unauthorized();
-                return Ok();
+                var response = await _dataService.FindAsync(model);
+                return Ok(response);
             }
             catch (Exception ex)
             {
@@ -61,7 +65,8 @@ namespace legallead.permissions.api.Controllers
             {
                 var user = _leadService.GetUserModel(Request, UserAccountAccess);
                 if (user == null) return Unauthorized();
-                return Ok();
+                var response = await _dataService.UploadAsync(model);
+                return Ok(response);
             }
             catch (Exception ex)
             {

--- a/src/api/legallead.permissions.api/Interfaces/IDbHistoryService.cs
+++ b/src/api/legallead.permissions.api/Interfaces/IDbHistoryService.cs
@@ -1,0 +1,12 @@
+﻿using legallead.permissions.api.Models;
+
+namespace legallead.permissions.api.Interfaces
+{
+    public interface IDbHistoryService
+    {
+        Task<DataRequestResponse> BeginAsync(BeginDataRequest model);
+        Task<DataRequestResponse> CompleteAsync(CompleteDataRequest model);
+        Task<IEnumerable<FindRequestResponse>> FindAsync(FindDataRequest model);
+        Task<bool> UploadAsync(UploadDataRequest model);
+    }
+}

--- a/src/api/legallead.permissions.api/Interfaces/IDbHistoryService.cs
+++ b/src/api/legallead.permissions.api/Interfaces/IDbHistoryService.cs
@@ -4,9 +4,9 @@ namespace legallead.permissions.api.Interfaces
 {
     public interface IDbHistoryService
     {
-        Task<DataRequestResponse> BeginAsync(BeginDataRequest model);
-        Task<DataRequestResponse> CompleteAsync(CompleteDataRequest model);
-        Task<IEnumerable<FindRequestResponse>> FindAsync(FindDataRequest model);
+        Task<DataRequestResponse?> BeginAsync(BeginDataRequest model);
+        Task<DataRequestResponse?> CompleteAsync(CompleteDataRequest model);
+        Task<IEnumerable<FindRequestResponse>?> FindAsync(FindDataRequest model);
         Task<bool> UploadAsync(UploadDataRequest model);
     }
 }

--- a/src/api/legallead.permissions.api/Models/BeginDataRequest.cs
+++ b/src/api/legallead.permissions.api/Models/BeginDataRequest.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace legallead.permissions.api.Models
+{
+    public class BeginDataRequest
+    {
+        [Range(0, 1000)]
+        public int CountyId { get; set; }
+        public DateTime SearchDate { get; set; }
+        [Range(0, 50)]
+        public int SearchTypeId { get; set; }
+        [Range(0, 50)]
+        public int CaseTypeId { get; set; }
+        [Range(0, 50)]
+        public int DistrictCourtId { get; set; }
+        [Range(0, 50)]
+        public int DistrictSearchTypeId { get; set; }
+    }
+}

--- a/src/api/legallead.permissions.api/Models/CompleteDataRequest.cs
+++ b/src/api/legallead.permissions.api/Models/CompleteDataRequest.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace legallead.permissions.api.Models
+{
+    public class CompleteDataRequest
+    {
+        [Range(0, 1000)]
+        public int CountyId { get; set; }
+        public DateTime SearchDate { get; set; }
+        [Range(0, 50)]
+        public int SearchTypeId { get; set; }
+        [Range(0, 50)]
+        public int CaseTypeId { get; set; }
+        [Range(0, 50)]
+        public int DistrictCourtId { get; set; }
+        [Range(0, 50)]
+        public int DistrictSearchTypeId { get; set; }
+    }
+}

--- a/src/api/legallead.permissions.api/Models/DataRequestResponse.cs
+++ b/src/api/legallead.permissions.api/Models/DataRequestResponse.cs
@@ -1,0 +1,16 @@
+﻿namespace legallead.permissions.api.Models
+{
+    public class DataRequestResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public int CountyId { get; set; }
+        public int RecordCount { get; set; }
+        public DateTime SearchDate { get; set; }
+        public int SearchTypeId { get; set; }
+        public int CaseTypeId { get; set; }
+        public int DistrictCourtId { get; set; }
+        public int DistrictSearchTypeId { get; set; }
+        public DateTime? CreateDate { get; set; }
+        public DateTime? CompleteDate { get; set; }
+    }
+}

--- a/src/api/legallead.permissions.api/Models/FindDataRequest.cs
+++ b/src/api/legallead.permissions.api/Models/FindDataRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace legallead.permissions.api.Models
+{
+    public class FindDataRequest
+    {
+        [Required]
+        [StringLength(50, MinimumLength = 10)]
+        public string Id { get; set; } = string.Empty;
+    }
+}

--- a/src/api/legallead.permissions.api/Models/FindRequestResponse.cs
+++ b/src/api/legallead.permissions.api/Models/FindRequestResponse.cs
@@ -1,0 +1,17 @@
+﻿namespace legallead.permissions.api.Models
+{
+    public class FindRequestResponse
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Zip { get; set; } = string.Empty;
+        public string Address1 { get; set; } = string.Empty;
+        public string Address2 { get; set; } = string.Empty;
+        public string Address3 { get; set; } = string.Empty;
+        public string CaseNumber { get; set; } = string.Empty;
+        public string DateFiled { get; set; } = string.Empty;
+        public string Court { get; set; } = string.Empty;
+        public string CaseType { get; set; } = string.Empty;
+        public string CaseStyle { get; set; } = string.Empty;
+        public string Plaintiff { get; set; } = string.Empty;
+    }
+}

--- a/src/api/legallead.permissions.api/Models/UploadDataRequest.cs
+++ b/src/api/legallead.permissions.api/Models/UploadDataRequest.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace legallead.permissions.api.Models
+{
+    public class UploadDataRequest
+    {
+        [Required]
+        [StringLength(50, MinimumLength = 10)]
+        public string Id { get; set; } = string.Empty;
+        public List<UploadHistoryItem> Contents { get; set; } = [];
+    }
+}

--- a/src/api/legallead.permissions.api/Models/UploadHistoryItem.cs
+++ b/src/api/legallead.permissions.api/Models/UploadHistoryItem.cs
@@ -1,0 +1,17 @@
+﻿namespace legallead.permissions.api.Models
+{
+    public class UploadHistoryItem
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Zip { get; set; } = string.Empty;
+        public string Address1 { get; set; } = string.Empty;
+        public string Address2 { get; set; } = string.Empty;
+        public string Address3 { get; set; } = string.Empty;
+        public string CaseNumber { get; set; } = string.Empty;
+        public string DateFiled { get; set; } = string.Empty;
+        public string Court { get; set; } = string.Empty;
+        public string CaseType { get; set; } = string.Empty;
+        public string CaseStyle { get; set; } = string.Empty;
+        public string Plaintiff { get; set; } = string.Empty;
+    }
+}

--- a/src/api/legallead.permissions.api/ObjectExtensions.cs
+++ b/src/api/legallead.permissions.api/ObjectExtensions.cs
@@ -95,6 +95,7 @@ namespace legallead.permissions.api
             services.AddScoped<ILeadUserRepository, LeadUserRepository>();
             services.AddScoped<ILeadSecurityService, LeadSecurityService>();
             services.AddScoped<ILeadAuthenicationService, LeadAuthenicationService>();
+            services.AddScoped<IDbHistoryRepository, DbHistoryRepository>();
             services.AddScoped<MailboxController>();
             services.AddScoped(d =>
             {

--- a/src/api/legallead.permissions.api/ObjectExtensions.cs
+++ b/src/api/legallead.permissions.api/ObjectExtensions.cs
@@ -164,6 +164,7 @@ namespace legallead.permissions.api
             services.AddScoped<HomeController>();
             services.AddScoped<ProfilesController>();
             services.AddScoped<AppController>();
+            services.AddScoped<DbController>();
             services.AddScoped(p =>
             {
                 return new PaymentController(payment,

--- a/src/api/legallead.permissions.api/ObjectExtensions.cs
+++ b/src/api/legallead.permissions.api/ObjectExtensions.cs
@@ -96,6 +96,7 @@ namespace legallead.permissions.api
             services.AddScoped<ILeadSecurityService, LeadSecurityService>();
             services.AddScoped<ILeadAuthenicationService, LeadAuthenicationService>();
             services.AddScoped<IDbHistoryRepository, DbHistoryRepository>();
+            services.AddScoped<IDbHistoryService, DbHistoryService>();
             services.AddScoped<MailboxController>();
             services.AddScoped(d =>
             {

--- a/src/api/legallead.permissions.api/Services/DbHistoryService.cs
+++ b/src/api/legallead.permissions.api/Services/DbHistoryService.cs
@@ -1,4 +1,5 @@
-﻿using legallead.jdbc.interfaces;
+﻿using AutoMapper;
+using legallead.jdbc.interfaces;
 using legallead.permissions.api.Models;
 
 namespace legallead.permissions.api.Services
@@ -6,25 +7,42 @@ namespace legallead.permissions.api.Services
     public class DbHistoryService(IDbHistoryRepository db) : IDbHistoryService
     {
         private readonly IDbHistoryRepository _db = db;
+        private readonly static IMapper _mapper = ModelMapper.Mapper;
 
-        public Task<DataRequestResponse> BeginAsync(BeginDataRequest model)
+        public async Task<DataRequestResponse?> BeginAsync(BeginDataRequest model)
         {
-            throw new NotImplementedException();
+            var src = _mapper.Map<DbHistoryRequest>(model);
+            var response = await _db.BeginAsync(src);
+            if (response == null) return null;
+            return _mapper.Map<DataRequestResponse>(response);
         }
 
-        public Task<DataRequestResponse> CompleteAsync(CompleteDataRequest model)
+        public async Task<DataRequestResponse?> CompleteAsync(CompleteDataRequest model)
         {
-            throw new NotImplementedException();
+            var src = _mapper.Map<DbHistoryRequest>(model);
+            var response = await _db.CompleteAsync(src);
+            if (response == null) return null;
+            return _mapper.Map<DataRequestResponse>(response);
         }
 
-        public Task<IEnumerable<FindRequestResponse>> FindAsync(FindDataRequest model)
+        public async Task<IEnumerable<FindRequestResponse>?> FindAsync(FindDataRequest model)
         {
-            throw new NotImplementedException();
+            var response = await _db.FindAsync(model.Id);
+            if (response == null) return null;
+            var list = new List<FindRequestResponse>();
+            response.ForEach(r => { list.Add(_mapper.Map<FindRequestResponse>(r)); });
+            return list;
         }
 
-        public Task<bool> UploadAsync(UploadDataRequest model)
+        public async Task<bool> UploadAsync(UploadDataRequest model)
         {
-            throw new NotImplementedException();
+            var src = new DbUploadRequest { Id = model.Id };
+            model.Contents.ForEach(m =>
+            {
+                src.Contents.Add(_mapper.Map<DbSearchHistoryResultBo>(m));
+            });
+            var response = await _db.UploadAsync(src);
+            return response;
         }
     }
 }

--- a/src/api/legallead.permissions.api/Services/DbHistoryService.cs
+++ b/src/api/legallead.permissions.api/Services/DbHistoryService.cs
@@ -1,0 +1,30 @@
+﻿using legallead.jdbc.interfaces;
+using legallead.permissions.api.Models;
+
+namespace legallead.permissions.api.Services
+{
+    public class DbHistoryService(IDbHistoryRepository db) : IDbHistoryService
+    {
+        private readonly IDbHistoryRepository _db = db;
+
+        public Task<DataRequestResponse> BeginAsync(BeginDataRequest model)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DataRequestResponse> CompleteAsync(CompleteDataRequest model)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<FindRequestResponse>> FindAsync(FindDataRequest model)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> UploadAsync(UploadDataRequest model)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/api/legallead.permissions.api/Services/HccRecordLoadingService.cs
+++ b/src/api/legallead.permissions.api/Services/HccRecordLoadingService.cs
@@ -24,7 +24,8 @@ namespace legallead.permissions.api.Services
             if (dataset.Count < 2) return;
             var subset = dataset.GetRange(1, dataset.Count - 1);
             var list = new List<UploadLineItem>();
-            foreach (var s in subset) {
+            foreach (var s in subset)
+            {
                 var values = s.Split('\t').ToList();
                 list.Add(new UploadLineItem
                 {

--- a/src/api/legallead.permissions.api/Utility/ModelMapper.cs
+++ b/src/api/legallead.permissions.api/Utility/ModelMapper.cs
@@ -106,6 +106,19 @@ namespace legallead.permissions.api
                 c.CreateMap<LevelRequestBo, DiscountRequestBo>();
 
                 c.CreateMap<DiscountRequestBo, LevelRequestBo>();
+
+
+                c.CreateMap<BeginDataRequest, DbHistoryRequest>();
+                c.CreateMap<DbHistoryRequest, BeginDataRequest>();
+
+                c.CreateMap<CompleteDataRequest, DbHistoryRequest>();
+                c.CreateMap<DbHistoryRequest, CompleteDataRequest>();
+
+                c.CreateMap<FindRequestResponse, DbSearchHistoryResultBo>();
+                c.CreateMap<DbSearchHistoryResultBo, FindRequestResponse>();
+
+                c.CreateMap<UploadHistoryItem, DbSearchHistoryResultBo>();
+                c.CreateMap<DbSearchHistoryResultBo, UploadHistoryItem>();
             });
         }
 

--- a/src/api/legallead.permissions.api/Utility/ModelMapper.cs
+++ b/src/api/legallead.permissions.api/Utility/ModelMapper.cs
@@ -119,6 +119,9 @@ namespace legallead.permissions.api
 
                 c.CreateMap<UploadHistoryItem, DbSearchHistoryResultBo>();
                 c.CreateMap<DbSearchHistoryResultBo, UploadHistoryItem>();
+
+                c.CreateMap<DataRequestResponse, DbSearchHistoryBo>();
+                c.CreateMap<DbSearchHistoryBo, DataRequestResponse>();
             });
         }
 

--- a/src/api/permissions.api.tests/Contollers/AppControllerTests.cs
+++ b/src/api/permissions.api.tests/Contollers/AppControllerTests.cs
@@ -1,15 +1,14 @@
+using legallead.jdbc.entities;
+using legallead.jdbc.interfaces;
 using legallead.permissions.api.Controllers;
 using legallead.permissions.api.Entities;
 using legallead.permissions.api.Interfaces;
 using legallead.permissions.api.Models;
 using legallead.permissions.api.Services;
-using legallead.jdbc.interfaces;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
-using legallead.jdbc.entities;
-using Moq;
 
 namespace permissions.api.tests.Contollers
 {
@@ -392,7 +391,7 @@ namespace permissions.api.tests.Contollers
             });
             Assert.Null(error);
         }
-        
+
         [Theory]
         [InlineData(0)]
         [InlineData(2)]

--- a/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
+++ b/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
@@ -200,6 +200,26 @@ namespace permissions.api.tests.Contollers
                         ControllerContext = controllerContext
                     };
                 });
+                collection.AddScoped(a =>
+                {
+                    var bo = LeadUserBoGenerator.GetBo(1, 1);
+                    var model = securityService.GetModel(bo);
+                    var token = LeadTokenService.GenerateToken("user account access credential", model);
+                    var mqRequest = a.GetRequiredService<Mock<HttpRequest>>();
+                    var leadsvc = a.GetRequiredService<ILeadAuthenicationService>();
+                    var headers = new HeaderDictionary
+                    {
+                        {
+                            "LEAD_IDENTITY", 
+                            new Microsoft.Extensions.Primitives.StringValues(token) 
+                        }
+                    };
+                    mqRequest.SetupGet(m => m.Headers).Returns(headers); 
+                    return new DbController(leadsvc)
+                    {
+                        ControllerContext = controllerContext
+                    };
+                });
                 collection.AddScoped<AppController>();
                 return collection.BuildServiceProvider();
             }
@@ -238,5 +258,6 @@ namespace permissions.api.tests.Contollers
         }
 
         private static readonly object locker = new();
+        private static readonly LeadSecurityService securityService = new();
     }
 }

--- a/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
+++ b/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
@@ -73,6 +73,7 @@ namespace permissions.api.tests.Contollers
                 var leadRepoMock = new Mock<ILeadUserRepository>();
                 var leadAuthMock = new Mock<ILeadAuthenicationService>();
                 var harrisDbMock = new Mock<IHarrisLoadRepository>();
+                var dbHistoryServiceMock = new Mock<IDbHistoryService>();
                 var collection = new ServiceCollection();
                 collection.AddScoped<ICountyAuthorizationService, CountyAuthorizationService>();
                 collection.AddScoped<IAppAuthenicationService, AppAuthenicationService>();
@@ -121,6 +122,8 @@ namespace permissions.api.tests.Contollers
                 collection.AddScoped(s => leadAuthMock.Object);
                 collection.AddScoped(s => harrisDbMock);
                 collection.AddScoped(s => harrisDbMock.Object);
+                collection.AddScoped(s => dbHistoryServiceMock);
+                collection.AddScoped(s => dbHistoryServiceMock.Object);
                 collection.AddScoped<ILeadSecurityService, LeadSecurityService>();
                 collection.AddScoped(p =>
                 {
@@ -205,7 +208,8 @@ namespace permissions.api.tests.Contollers
                     var bo = LeadUserBoGenerator.GetBo(1, 1);
                     var model = securityService.GetModel(bo);
                     var token = LeadTokenService.GenerateToken("user account access credential", model);
-                    var mqRequest = a.GetRequiredService<Mock<HttpRequest>>();
+                    var mqRequest = a.GetRequiredService<Mock<HttpRequest>>(); 
+                    var mqDb = a.GetRequiredService<IDbHistoryService>();
                     var leadsvc = a.GetRequiredService<ILeadAuthenicationService>();
                     var headers = new HeaderDictionary
                     {
@@ -215,7 +219,7 @@ namespace permissions.api.tests.Contollers
                         }
                     };
                     mqRequest.SetupGet(m => m.Headers).Returns(headers);
-                    return new DbController(leadsvc)
+                    return new DbController(leadsvc, mqDb)
                     {
                         ControllerContext = controllerContext
                     };

--- a/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
+++ b/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
@@ -210,11 +210,11 @@ namespace permissions.api.tests.Contollers
                     var headers = new HeaderDictionary
                     {
                         {
-                            "LEAD_IDENTITY", 
-                            new Microsoft.Extensions.Primitives.StringValues(token) 
+                            "LEAD_IDENTITY",
+                            new Microsoft.Extensions.Primitives.StringValues(token)
                         }
                     };
-                    mqRequest.SetupGet(m => m.Headers).Returns(headers); 
+                    mqRequest.SetupGet(m => m.Headers).Returns(headers);
                     return new DbController(leadsvc)
                     {
                         ControllerContext = controllerContext

--- a/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
+++ b/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
@@ -1,0 +1,114 @@
+using legallead.permissions.api.Controllers;
+using legallead.permissions.api.Entities;
+using legallead.permissions.api.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace permissions.api.tests.Contollers
+{
+    public class DbControllerTests : BaseControllerTest
+    {
+        [Fact]
+        public void ControllerCanBeCreated()
+        {
+            var error = Record.Exception(() =>
+            {
+                var provider = GetProvider();
+                _ = provider.GetRequiredService<DbController>();
+            });
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task ControllerCanBeginAsync(int testId)
+        {
+            var error = await Record.ExceptionAsync(async () =>
+            {
+                var provider = GetProvider();
+                var sut = provider.GetRequiredService<DbController>();
+                SetupUserInteractions(testId, provider);
+                _ = await sut.BeginAsync(new());
+            });
+            Assert.Null(error);
+        }
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task ControllerCanCompleteAsync(int testId)
+        {
+            var error = await Record.ExceptionAsync(async () =>
+            {
+                var provider = GetProvider();
+                var sut = provider.GetRequiredService<DbController>();
+                SetupUserInteractions(testId, provider);
+                _ = await sut.CompleteAsync(new());
+            });
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task ControllerCanFindAsync(int testId)
+        {
+            var error = await Record.ExceptionAsync(async () =>
+            {
+                var provider = GetProvider();
+                var sut = provider.GetRequiredService<DbController>();
+                SetupUserInteractions(testId, provider);
+                _ = await sut.FindAsync(new());
+            });
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task ControllerCanUploadAsync(int testId)
+        {
+            var error = await Record.ExceptionAsync(async () =>
+            {
+                var provider = GetProvider();
+                var sut = provider.GetRequiredService<DbController>();
+                SetupUserInteractions(testId, provider);
+                _ = await sut.UploadAsync(new());
+            });
+            Assert.Null(error);
+        }
+
+
+
+        private static void SetupUserInteractions(int testId, IServiceProvider provider)
+        {
+            LeadUserModel? empty = null;
+            LeadUserModel user = new();
+            var leadsvc = provider.GetRequiredService<Mock<ILeadAuthenicationService>>();
+            if (testId == -1)
+            {
+                leadsvc.Setup(x => x.GetUserModel(
+                    It.IsAny<HttpRequest>(),
+                    It.IsAny<string>())).Throws<InvalidOperationException>();
+            }
+            if (testId == 0)
+            {
+                leadsvc.Setup(x => x.GetUserModel(
+                    It.IsAny<HttpRequest>(),
+                    It.IsAny<string>())).Returns(empty);
+            }
+            if (testId == 1)
+            {
+                leadsvc.Setup(x => x.GetUserModel(
+                    It.IsAny<HttpRequest>(),
+                    It.IsAny<string>())).Returns(user);
+            }
+        }
+
+    }
+}
+

--- a/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
+++ b/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
@@ -1,8 +1,10 @@
 using legallead.permissions.api.Controllers;
 using legallead.permissions.api.Entities;
 using legallead.permissions.api.Interfaces;
+using legallead.permissions.api.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 
 namespace permissions.api.tests.Contollers
 {
@@ -107,6 +109,13 @@ namespace permissions.api.tests.Contollers
                     It.IsAny<HttpRequest>(),
                     It.IsAny<string>())).Returns(user);
             }
+            var dbmock = provider.GetRequiredService<Mock<IDbHistoryService>>();
+            var rsp = new DataRequestResponse();
+            var rlist = new List<FindRequestResponse>();
+            dbmock.Setup(x => x.BeginAsync(It.IsAny<BeginDataRequest>())).ReturnsAsync(rsp);
+            dbmock.Setup(x => x.CompleteAsync(It.IsAny<CompleteDataRequest>())).ReturnsAsync(rsp);
+            dbmock.Setup(x => x.FindAsync(It.IsAny<FindDataRequest>())).ReturnsAsync(rlist);
+            dbmock.Setup(x => x.UploadAsync(It.IsAny<UploadDataRequest>())).ReturnsAsync(true);
         }
 
     }

--- a/src/api/permissions.api.tests/Services/DbHistoryServiceTests.cs
+++ b/src/api/permissions.api.tests/Services/DbHistoryServiceTests.cs
@@ -1,0 +1,272 @@
+﻿using legallead.jdbc.entities;
+using legallead.jdbc.interfaces;
+using legallead.jdbc.models;
+using legallead.permissions.api;
+using legallead.permissions.api.Interfaces;
+using legallead.permissions.api.Models;
+using legallead.permissions.api.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace permissions.api.tests.Services
+{
+    public class DbHistoryServiceTests
+    {
+        [Fact]
+        public void ServiceCanBeCreated()
+        {
+            var provider = GetDbProvider();
+            var service = provider.GetRequiredService<IDbHistoryService>();
+            Assert.NotNull(service);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task ServiceCanBeginAsync(int responseId)
+        {
+            var provider = GetDbProvider();
+            var service = provider.GetRequiredService<IDbHistoryService>();
+            var request = beginfaker.Generate();
+            var response = responseId == 0 ? null : historyfaker.Generate();
+            var mock = provider.GetRequiredService<Mock<IDbHistoryRepository>>();
+            mock.Setup(m => m.BeginAsync(It.IsAny<DbHistoryRequest>())).ReturnsAsync(response);
+            await service.BeginAsync(request);
+            mock.Verify(m => m.BeginAsync(It.IsAny<DbHistoryRequest>()));
+        }
+
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        public async Task ServiceCanCompleteAsync(int responseId)
+        {
+            var provider = GetDbProvider();
+            var service = provider.GetRequiredService<IDbHistoryService>();
+            var request = completefaker.Generate();
+            var response = responseId == 0 ? null : historyfaker.Generate();
+            var mock = provider.GetRequiredService<Mock<IDbHistoryRepository>>();
+            mock.Setup(m => m.CompleteAsync(It.IsAny<DbHistoryRequest>())).ReturnsAsync(response);
+            await service.CompleteAsync(request);
+            mock.Verify(m => m.CompleteAsync(It.IsAny<DbHistoryRequest>()));
+        }
+
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(100)]
+        public async Task ServiceCanFindAsync(int responseId)
+        {
+            var provider = GetDbProvider();
+            var service = provider.GetRequiredService<IDbHistoryService>();
+            var request = new Faker().Random.Guid().ToString();
+            var response = responseId == -1 ? null : resultfaker.Generate(responseId);
+            var mock = provider.GetRequiredService<Mock<IDbHistoryRepository>>();
+            mock.Setup(m => m.FindAsync(It.IsAny<string>())).ReturnsAsync(response);
+            await service.FindAsync(new FindDataRequest { Id = request });
+            mock.Verify(m => m.FindAsync(It.IsAny<string>()));
+        }
+
+
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(100)]
+        public async Task ServiceCanUploadAsync(int responseId)
+        {
+            var fkr = new Faker();
+            var provider = GetDbProvider();
+            var service = provider.GetRequiredService<IDbHistoryService>();
+            var requestid = fkr.Random.Guid().ToString();
+            var data = uploadfaker.Generate(responseId);
+            var request = new UploadDataRequest { Id = requestid, Contents = data };
+            var response = fkr.Random.Bool();
+            var mock = provider.GetRequiredService<Mock<IDbHistoryRepository>>();
+            mock.Setup(m => m.UploadAsync(It.IsAny<DbUploadRequest>())).ReturnsAsync(response);
+            await service.UploadAsync(request);
+            mock.Verify(m => m.UploadAsync(It.IsAny<DbUploadRequest>()));
+        }
+
+        [Fact]
+        public void MapperCanMapBeqinRequest()
+        {
+            var faker = GetFaker<BeginDataRequest>();
+            if (faker == null) Assert.Fail();
+            var obj = faker.Generate();
+            var mapped = ModelMapper.Mapper.Map<DbHistoryRequest>(obj);
+            Assert.NotNull(mapped);
+            Assert.Equal(obj.SearchDate, mapped.SearchDate);
+            Assert.Equal(obj.CountyId, mapped.CountyId);
+            Assert.Equal(obj.SearchTypeId, mapped.SearchTypeId);
+            Assert.Equal(obj.CaseTypeId, mapped.CaseTypeId);
+            Assert.Equal(obj.DistrictCourtId, mapped.DistrictCourtId);
+            Assert.Equal(obj.DistrictSearchTypeId, mapped.DistrictSearchTypeId);
+        }
+
+        [Fact]
+        public void MapperCanMapCompleteRequest()
+        {
+            var faker = GetFaker<CompleteDataRequest>();
+            if (faker == null) Assert.Fail();
+            var obj = faker.Generate();
+            var mapped = ModelMapper.Mapper.Map<DbHistoryRequest>(obj);
+            Assert.NotNull(mapped);
+            Assert.Equal(obj.SearchDate, mapped.SearchDate);
+            Assert.Equal(obj.CountyId, mapped.CountyId);
+            Assert.Equal(obj.SearchTypeId, mapped.SearchTypeId);
+            Assert.Equal(obj.CaseTypeId, mapped.CaseTypeId);
+            Assert.Equal(obj.DistrictCourtId, mapped.DistrictCourtId);
+            Assert.Equal(obj.DistrictSearchTypeId, mapped.DistrictSearchTypeId);
+        }
+
+        [Fact]
+        public void MapperCanMapFindRequest()
+        {
+            var faker = GetFaker<FindRequestResponse>();
+            if (faker == null) Assert.Fail();
+            var obj = faker.Generate();
+            var mapped = ModelMapper.Mapper.Map<DbSearchHistoryResultBo>(obj);
+            Assert.NotNull(mapped);
+            Assert.Equal(obj.Name, mapped.Name);
+            Assert.Equal(obj.Zip, mapped.Zip);
+            Assert.Equal(obj.Address1, mapped.Address1);
+            Assert.Equal(obj.Address2, mapped.Address2);
+            Assert.Equal(obj.Address3, mapped.Address3);
+            Assert.Equal(obj.CaseNumber, mapped.CaseNumber);
+            Assert.Equal(obj.Court, mapped.Court);
+            Assert.Equal(obj.CaseType, mapped.CaseType);
+            Assert.Equal(obj.Plaintiff, mapped.Plaintiff);
+        }
+
+        [Fact]
+        public void MapperCanMapUploadRequest()
+        {
+            var faker = GetFaker<UploadHistoryItem>();
+            if (faker == null) Assert.Fail();
+            var obj = faker.Generate();
+            var mapped = ModelMapper.Mapper.Map<DbSearchHistoryResultBo>(obj);
+            Assert.NotNull(mapped);
+            Assert.Equal(obj.Name, mapped.Name);
+            Assert.Equal(obj.Zip, mapped.Zip);
+            Assert.Equal(obj.Address1, mapped.Address1);
+            Assert.Equal(obj.Address2, mapped.Address2);
+            Assert.Equal(obj.Address3, mapped.Address3);
+            Assert.Equal(obj.CaseNumber, mapped.CaseNumber);
+            Assert.Equal(obj.Court, mapped.Court);
+            Assert.Equal(obj.CaseType, mapped.CaseType);
+            Assert.Equal(obj.Plaintiff, mapped.Plaintiff);
+        }
+        [Fact]
+        public void MapperCanMapFindResponse()
+        {
+            var src = resultfaker.Generate();
+            var dst = ModelMapper.Mapper.Map<FindRequestResponse>(src);
+            Assert.NotNull(dst);
+        }
+
+        private static ServiceProvider GetDbProvider()
+        {
+            var services = new ServiceCollection();
+            var mock = new Mock<IDbHistoryRepository>();
+            services.AddSingleton(mock);
+            services.AddSingleton(mock.Object);
+            services.AddSingleton<IDbHistoryService, DbHistoryService>();
+            return services.BuildServiceProvider();
+        }
+
+        private static Faker<T>? GetFaker<T>() where T : class
+        {
+            var type = typeof(T);
+            if (type == typeof(BeginDataRequest)) return beginfaker as Faker<T>;
+            if (type == typeof(CompleteDataRequest)) return completefaker as Faker<T>;
+            if (type == typeof(FindRequestResponse)) return findfaker as Faker<T>;
+            if (type == typeof(UploadHistoryItem)) return uploadfaker as Faker<T>;
+            return null;
+        }
+
+        private static readonly Faker<BeginDataRequest>
+            beginfaker = new Faker<BeginDataRequest>()
+            .RuleFor(x => x.SearchDate, y => y.Date.Past())
+            .RuleFor(x => x.CountyId, y => y.Random.Int(1, 1000))
+            .RuleFor(x => x.SearchTypeId, y => y.Random.Int(1, 50))
+            .RuleFor(x => x.CaseTypeId, y => y.Random.Int(1, 50))
+            .RuleFor(x => x.DistrictCourtId, y => y.Random.Int(1, 50))
+            .RuleFor(x => x.DistrictSearchTypeId, y => y.Random.Int(1, 50));
+
+        private static readonly Faker<CompleteDataRequest>
+            completefaker = new Faker<CompleteDataRequest>()
+            .RuleFor(x => x.SearchDate, y => y.Date.Past())
+            .RuleFor(x => x.CountyId, y => y.Random.Int(0, 1000))
+            .RuleFor(x => x.SearchTypeId, y => y.Random.Int(0, 50))
+            .RuleFor(x => x.CaseTypeId, y => y.Random.Int(0, 50))
+            .RuleFor(x => x.DistrictCourtId, y => y.Random.Int(0, 50))
+            .RuleFor(x => x.DistrictSearchTypeId, y => y.Random.Int(0, 50));
+
+        private static readonly Faker<FindRequestResponse>
+            findfaker = new Faker<FindRequestResponse>()
+            .RuleFor(x => x.Name, y => y.Person.FullName)
+            .RuleFor(x => x.Zip, y => y.Address.ZipCode())
+            .RuleFor(x => x.Address1, y => y.Address.StreetAddress(true))
+            .RuleFor(x => x.Address2, y =>
+            {
+                var hasValue = y.Random.Bool();
+                if (!hasValue) return string.Empty;
+                return y.Address.SecondaryAddress();
+            })
+            .RuleFor(x => x.Address3, y =>
+            {
+                var addr = $"{y.Address.City()}, {y.Address.StateAbbr()}";
+                return addr;
+            })
+            .RuleFor(x => x.CaseNumber, y => y.Random.AlphaNumeric(15))
+            .RuleFor(x => x.Court, y => y.Random.AlphaNumeric(5))
+            .RuleFor(x => x.CaseType, y => y.Random.AlphaNumeric(5))
+            .RuleFor(x => x.CaseStyle, y => y.Lorem.Sentence(7))
+            .RuleFor(x => x.Plaintiff, y => y.Person.FullName);
+
+        private static readonly Faker<UploadHistoryItem>
+            uploadfaker = new Faker<UploadHistoryItem>()
+            .RuleFor(x => x.Name, y => y.Person.FullName)
+            .RuleFor(x => x.Zip, y => y.Address.ZipCode())
+            .RuleFor(x => x.Address1, y => y.Address.StreetAddress(true))
+            .RuleFor(x => x.Address2, y =>
+            {
+                var hasValue = y.Random.Bool();
+                if (!hasValue) return string.Empty;
+                return y.Address.SecondaryAddress();
+            })
+            .RuleFor(x => x.Address3, y =>
+            {
+                var addr = $"{y.Address.City()}, {y.Address.StateAbbr()}";
+                return addr;
+            })
+            .RuleFor(x => x.CaseNumber, y => y.Random.AlphaNumeric(15))
+            .RuleFor(x => x.Court, y => y.Random.AlphaNumeric(5))
+            .RuleFor(x => x.CaseType, y => y.Random.AlphaNumeric(5))
+            .RuleFor(x => x.CaseStyle, y => y.Lorem.Sentence(7))
+            .RuleFor(x => x.Plaintiff, y => y.Person.FullName);
+
+        private static readonly Faker<DbSearchHistoryBo>
+            historyfaker = new Faker<DbSearchHistoryBo>()
+            .RuleFor(x => x.SearchDate, y => y.Date.Past())
+            .RuleFor(x => x.CountyId, y => y.Random.Int(1, 1000))
+            .RuleFor(x => x.SearchTypeId, y => y.Random.Int(1, 50))
+            .RuleFor(x => x.CaseTypeId, y => y.Random.Int(1, 50))
+            .RuleFor(x => x.DistrictCourtId, y => y.Random.Int(1, 50))
+            .RuleFor(x => x.DistrictSearchTypeId, y => y.Random.Int(1, 50));
+
+        private static readonly Faker<DbSearchHistoryResultBo>
+            resultfaker = new Faker<DbSearchHistoryResultBo>()
+            .FinishWith((fk, dest) =>
+            {
+                var src = uploadfaker.Generate();
+                var tmp = ModelMapper.Mapper.Map<DbSearchHistoryResultBo>(src);
+                tmp.Id = fk.Random.Guid().ToString();
+                tmp.CreateDate = fk.Date.Recent();
+                tmp.SearchHistoryId = fk.Random.Guid().ToString();
+                dest = tmp;
+            });
+    }
+}

--- a/src/api/permissions.api.tests/Services/HccRecordLoadingServiceTests.cs
+++ b/src/api/permissions.api.tests/Services/HccRecordLoadingServiceTests.cs
@@ -1,6 +1,5 @@
 using legallead.jdbc.interfaces;
 using legallead.permissions.api.Services;
-using Stripe;
 using System.Text;
 
 namespace permissions.api.tests.Services


### PR DESCRIPTION
As an api, 
I want to expose new methods
So that authenicated users can read and write search results to common database.
