### PR TITLE
PR | API | Excel Name Behavior

### DIFF
--- a/release/legallead.permissions.api.release.json
+++ b/release/legallead.permissions.api.release.json
@@ -1,5 +1,10 @@
 [
 	{
+		"name": "3.2.444.--",
+		"description": "API - allow persistence of excel generated file name",
+		"date": "2024-12-26 20:15:00"
+	},
+	{
 		"name": "3.2.442.--",
 		"description": "API - support invoicing for customers",
 		"date": "2024-12-26 20:15:00"

--- a/src/api/legallead.permissions.api/Models/CompleteUsageRecordRequest.cs
+++ b/src/api/legallead.permissions.api/Models/CompleteUsageRecordRequest.cs
@@ -4,6 +4,6 @@ namespace legallead.permissions.api.Models
     {
         public string UsageRecordId { get; set; } = string.Empty;
         public int RecordCount { get; set; }
-        public string ExcelFileName { get; set; } = string.Empty;
+        public string ExcelName { get; set; } = string.Empty;
     }
 }

--- a/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
+++ b/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
@@ -427,22 +427,13 @@ namespace permissions.api.tests.Contollers
             private static readonly Faker<CompleteUsageRecordRequest> completeFaker =
                 new Faker<CompleteUsageRecordRequest>()
                 .RuleFor(x => x.UsageRecordId, y => y.Random.AlphaNumeric(16))
-                .RuleFor(x => x.RecordCount, y => y.Random.Int(1, 100) * 10);
+                .RuleFor(x => x.RecordCount, y => y.Random.Int(1, 100) * 10)
+                .RuleFor(x => x.ExcelName, y=> y.System.FileName(".xlsx"));
 
             private static readonly Faker<GetMonthlyLimitRequest> getlimitFaker =
                 new Faker<GetMonthlyLimitRequest>()
                 .RuleFor(x => x.LeadId, y => y.Random.AlphaNumeric(16))
                 .RuleFor(x => x.CountyId, y => y.Random.Int(1, 50));
-
-            private static readonly Faker<DbCountyUsageLimitBo> limitBo =
-                new Faker<DbCountyUsageLimitBo>()
-                .RuleFor(x => x.Id, y => y.Random.Guid().ToString())
-                .RuleFor(x => x.LeadUserId, y => y.Random.Guid().ToString())
-                .RuleFor(x => x.CountyId, y => y.Random.Int(1, 101))
-                .RuleFor(x => x.IsActive, y => y.Random.Bool())
-                .RuleFor(x => x.MaxRecords, y => y.Random.Int(5, 2500))
-                .RuleFor(x => x.CompleteDate, y => y.Date.Recent())
-                .RuleFor(x => x.CreateDate, y => y.Date.Recent());
 
             private static readonly Faker<GetUsageRequest> getusageFaker =
                 new Faker<GetUsageRequest>()


### PR DESCRIPTION
# Discussion
feat: allow user to save excel file name

## Details
- when a user search completes
- the program needs to save the excel file name
- so that records can be made available to users only upon payment.
