### PR TITLE
feat: api add method to fetch excel detail by id

### DIFF
--- a/release/legallead.permissions.api.release.json
+++ b/release/legallead.permissions.api.release.json
@@ -1,5 +1,10 @@
 [
 	{
+		"name": "3.2.445.--",
+		"description": "API - return status of excel generated file",
+		"date": "2025-01-04 15:00:00"
+	},
+	{
 		"name": "3.2.444.--",
 		"description": "API - allow persistence of excel generated file name",
 		"date": "2024-12-26 20:15:00"

--- a/src/api/legallead.permissions.api/Controllers/DbController.cs
+++ b/src/api/legallead.permissions.api/Controllers/DbController.cs
@@ -169,6 +169,14 @@ namespace legallead.permissions.api.Controllers
             return Ok(response);
         }
 
+        [HttpPost("usage-get-excel-file-detail")]
+        public async Task<IActionResult> GetExcelDetailByIdAsync(CompleteUsageRecordRequest request)
+        {
+            if (string.IsNullOrEmpty(request.UsageRecordId)) return BadRequest();
+            var response = await _usageService.GetExcelDetailAsync(request.UsageRecordId);
+            return Ok(response);
+        }
+
         [HttpPost("usage-set-monthly-limit")]
         public async Task<IActionResult> UsageSetLimitAsync(SetMonthlyLimitRequest request)
         {

--- a/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
+++ b/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
@@ -33,6 +33,6 @@ namespace legallead.permissions.api.Interfaces
         /// gets monthly usage summary for specified user
         /// </summary>
         Task<GetUsageResponse> GetUsageSummaryAsync(GetUsageRequest model);
-
+        Task<GetExcelDetailByIdResponse> GetExcelDetailAsync(string id);
     }
 }

--- a/src/api/legallead.permissions.api/Models/GetExcelDetailByIdResponse.cs
+++ b/src/api/legallead.permissions.api/Models/GetExcelDetailByIdResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace legallead.permissions.api.Models
+{
+    public class GetExcelDetailByIdResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public bool IsCompleted { get; set; }
+    }
+}

--- a/src/api/legallead.permissions.api/Services/UserUsageService.cs
+++ b/src/api/legallead.permissions.api/Services/UserUsageService.cs
@@ -52,6 +52,19 @@ namespace legallead.permissions.api.Services
             return response;
         }
 
+        public async Task<GetExcelDetailByIdResponse> GetExcelDetailAsync(string id)
+        {
+            var dto = await db.GetUsageFileDetails(id);
+            var response = new GetExcelDetailByIdResponse
+            {
+                Id = id,
+                IsCompleted = dto.IsCompleted,
+                Name = dto.Name,
+                Password = dto.Password,
+            };
+            return response;
+        }
+
         public async Task<SetMonthlyLimitResponse> SetMonthlyLimitAsync(SetMonthlyLimitRequest model)
         {
             var response = mapper.Map<SetMonthlyLimitResponse>(model);

--- a/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
+++ b/src/api/permissions.api.tests/Contollers/DbControllerTests.cs
@@ -294,6 +294,33 @@ namespace permissions.api.tests.Contollers
         [Theory]
         [InlineData(0)]
         [InlineData(1)]
+        public async Task ControllerCanGetExcelDetailByIdAsync(int testId)
+        {
+            var error = await Record.ExceptionAsync(async () =>
+            {
+                var provider = GetProvider();
+                var sut = provider.GetRequiredService<DbController>();
+                var mock = provider.GetRequiredService<Mock<IUserUsageService>>();
+                var request = "get-record-test";
+                var data = new GetExcelDetailByIdResponse { };
+                mock.Setup(m => m.GetExcelDetailAsync(It.IsAny<string>())).ReturnsAsync(data);
+                if (testId == 0) request = string.Empty;
+                var response = await sut.GetExcelDetailByIdAsync(new() { UsageRecordId = request });
+                if (testId == 0)
+                {
+                    Assert.IsAssignableFrom<BadRequestResult>(response);
+                }
+                else
+                {
+                    Assert.IsAssignableFrom<OkObjectResult>(response);
+                }
+            });
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
         public async Task ControllerCanSetUsageLimitAsync(int testId)
         {
             var error = await Record.ExceptionAsync(async () =>

--- a/src/api/permissions.api.tests/Services/UserUsageServiceTests.cs
+++ b/src/api/permissions.api.tests/Services/UserUsageServiceTests.cs
@@ -140,6 +140,18 @@ namespace permissions.api.tests.Services
             mock.Verify(s => s.GetUsageSummary(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<bool>()));
         }
 
+        [Fact]
+        public async Task ServicCanGetExcelDetailAsync()
+        {
+            const string request = "test-request-id";
+            var sut = new UsageServiceMock();
+            var service = sut.Service;
+            var mock = sut.Repository;
+            var response = new ExcelFileNameResponse { };
+            mock.Setup(s => s.GetUsageFileDetails(It.IsAny<string>())).ReturnsAsync(response);
+            await service.GetExcelDetailAsync(request);
+            mock.Verify(s => s.GetUsageFileDetails(It.IsAny<string>()));
+        }
 
         [Theory]
         [InlineData(0)]


### PR DESCRIPTION
# Comments
As an API,
I want to expose a method to fetch excel content details, so that the caller can act upon invoice paid response.