### PR TITLE
DB | File Operations

### DIFF
--- a/src/db/component/legallead.jdbc/attr/CountyFileStatusAttribute.cs
+++ b/src/db/component/legallead.jdbc/attr/CountyFileStatusAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace legallead.jdbc.attr
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class CountyFileStatusAttribute : ValidationAttribute
+    {
+        private static readonly List<string> _fileStatuses =
+        [
+            "EMPTY",
+            "ENCODED",
+            "DECODED",
+            "DOWNLOADED"
+        ];
+
+        public string Name { get; set; } = string.Empty;
+
+        public override bool IsValid(object? value)
+        {
+            if (value == null) return false;
+            if (value is not string permission) return false;
+            return _fileStatuses.Contains(permission, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/attr/CountyFileTypeAttribute.cs
+++ b/src/db/component/legallead.jdbc/attr/CountyFileTypeAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace legallead.jdbc.attr
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
+    public class CountyFileTypeAttribute : ValidationAttribute
+    {
+        private static readonly List<string> _fileTypes = new()
+        {
+            "NONE",
+            "EXL",
+            "CSV",
+            "JSON"
+        };
+
+        public string Name { get; set; } = string.Empty;
+
+        public override bool IsValid(object? value)
+        {
+            if (value == null) return false;
+            if (value is not string permission) return false;
+            return _fileTypes.Contains(permission, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/entities/DbCountyFileDto.cs
+++ b/src/db/component/legallead.jdbc/entities/DbCountyFileDto.cs
@@ -1,0 +1,42 @@
+﻿namespace legallead.jdbc.entities
+{
+    [TargetTable(TableName = "DBCOUNTYFILE")]
+    public class DbCountyFileDto : BaseDto
+    {
+        public string? DbCountyFileId { get; set; }
+        public int? FileTypeId { get; set; }
+        public int? FileStatusId { get; set; }
+        public string? Content { get; set; }
+
+        public override object? this[string field]
+        {
+            get
+            {
+                if (field == null) return null;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return null;
+                if (fieldName.Equals("Id", Comparison)) return Id;
+                if (fieldName.Equals("DbCountyFileId", Comparison)) return DbCountyFileId;
+                if (fieldName.Equals("FileTypeId", Comparison)) return FileTypeId;
+                if (fieldName.Equals("FileStatusId", Comparison)) return FileStatusId;
+                return Content;
+            }
+            set
+            {
+                if (field == null) return;
+                var fieldName = FieldList.Find(x => x.Equals(field, Comparison));
+                if (fieldName == null) return;
+                if (fieldName.Equals("Id", Comparison))
+                {
+                    Id = ChangeType<string>(value) ?? string.Empty;
+                    return;
+                }
+                if (fieldName.Equals("DbCountyFileId", Comparison)) { DbCountyFileId = ChangeType<string?>(value); return; }
+                if (fieldName.Equals("FileTypeId", Comparison)) { FileTypeId = ChangeType<int?>(value); return; }
+                if (fieldName.Equals("FileStatusId", Comparison)) { FileStatusId = ChangeType<int?>(value); return; }
+                if (fieldName.Equals("Content", Comparison)) { Content = ChangeType<string?>(value); }
+            }
+        }
+
+    }
+}

--- a/src/db/component/legallead.jdbc/implementations/CountyFileRepository.cs
+++ b/src/db/component/legallead.jdbc/implementations/CountyFileRepository.cs
@@ -48,7 +48,7 @@ namespace legallead.jdbc.implementations
             var current = await GetContentAsync(request);
             if (current == null)
             {
-                return new(false, "Invalid record index.");
+                return new(false, invalidIndexMessage);
             }
             var prc = ProcedureNames.SetContentAndStatusProc;
             var parameters = new DynamicParameters();
@@ -90,7 +90,7 @@ namespace legallead.jdbc.implementations
             var current = await GetContentAsync(request);
             if (current == null)
             {
-                return new(false, "Invalid record index.");
+                return new(false, invalidIndexMessage);
             }
             var prc = ProcedureNames.SetContentAndStatusProc;
             var parameters = new DynamicParameters();
@@ -132,6 +132,7 @@ namespace legallead.jdbc.implementations
         private const string fileTypeName = "fileTypeName";
         private const string fileStatusName = "fileStatusName";
         private const string fileContent = "fileContent";
+        private const string invalidIndexMessage = "Invalid record index.";
         private static readonly Dictionary<int, string> statusNames = new()
         {
             {0, "EMPTY" },

--- a/src/db/component/legallead.jdbc/implementations/CountyFileRepository.cs
+++ b/src/db/component/legallead.jdbc/implementations/CountyFileRepository.cs
@@ -1,0 +1,157 @@
+﻿using Dapper;
+using legallead.jdbc.entities;
+using legallead.jdbc.helpers;
+using legallead.jdbc.interfaces;
+using legallead.jdbc.models;
+
+namespace legallead.jdbc.implementations
+{
+    public class CountyFileRepository(DataContext context) :
+        BaseRepository<DbCountyFileDto>(context), ICountyFileRepository
+    {
+
+        public async Task<DbCountyFileModel?> GetContentAsync(DbCountyFileModel request)
+        {
+            _ = await InitializeAsync();
+            var prc = ProcedureNames.GetProc;
+            var parameters = new DynamicParameters();
+            parameters.Add(fileId, request.Id);
+            try
+            {
+                using var connection = _context.CreateConnection();
+                var response = await _command.QuerySingleOrDefaultAsync<DbCountyFileDto>(connection, prc, parameters);
+                return MapFrom(response);
+            }
+            catch (Exception)
+            {
+                return default;
+            }
+        }
+
+        public async Task<bool> InitializeAsync()
+        {
+            var prc = ProcedureNames.InitProc;
+            try
+            {
+                using var connection = _context.CreateConnection();
+                await _command.ExecuteAsync(connection, prc);
+                return true;
+            }
+            catch (Exception)
+            {
+                return default;
+            }
+        }
+
+        public async Task<KeyValuePair<bool, string>> UpdateContentAsync(DbCountyFileModel request)
+        {
+            var current = await GetContentAsync(request);
+            if (current == null)
+            {
+                return new(false, "Invalid record index.");
+            }
+            var prc = ProcedureNames.SetContentAndStatusProc;
+            var parameters = new DynamicParameters();
+            parameters.Add(fileId, request.Id);
+            parameters.Add(fileStatusName, current.FileStatus);
+            parameters.Add(fileContent, request.FileContent);
+            try
+            {
+                using var connection = _context.CreateConnection();
+                await _command.ExecuteAsync(connection, prc, parameters);
+                return new(true, "");
+            }
+            catch (Exception ex)
+            {
+                return new(false, ex.Message);
+            }
+        }
+
+        public async Task<KeyValuePair<bool, string>> UpdateTypeAsync(DbCountyFileModel request)
+        {
+            var prc = ProcedureNames.SetFileTypeProc;
+            var parameters = new DynamicParameters();
+            parameters.Add(fileId, request.Id);
+            parameters.Add(fileTypeName, request.FileType);
+            try
+            {
+                using var connection = _context.CreateConnection();
+                await _command.ExecuteAsync(connection, prc, parameters);
+                return new(true, "");
+            }
+            catch (Exception ex)
+            {
+                return new(false, ex.Message);
+            }
+        }
+
+        public async Task<KeyValuePair<bool, string>> UpdateStatusAsync(DbCountyFileModel request)
+        {
+            var current = await GetContentAsync(request);
+            if (current == null)
+            {
+                return new(false, "Invalid record index.");
+            }
+            var prc = ProcedureNames.SetContentAndStatusProc;
+            var parameters = new DynamicParameters();
+            parameters.Add(fileId, request.Id);
+            parameters.Add(fileStatusName, request.FileStatus);
+            parameters.Add(fileContent, current.FileContent);
+            try
+            {
+                using var connection = _context.CreateConnection();
+                await _command.ExecuteAsync(connection, prc, parameters);
+                return new(true, "");
+            }
+            catch (Exception ex)
+            {
+                return new(false, ex.Message);
+            }
+        }
+        private static DbCountyFileModel? MapFrom(DbCountyFileDto? dto)
+        {
+            if (dto == null) return null;
+            var response = new DbCountyFileModel
+            {
+                Id = dto.DbCountyFileId ?? string.Empty,
+                FileContent = dto.Content ?? string.Empty,
+                FileStatus = FindValue(dto.FileStatusId.GetValueOrDefault(), statusNames),
+                FileType = FindValue(dto.FileTypeId.GetValueOrDefault(), typeNames),
+            };
+
+            return response;
+        }
+
+
+        private static string FindValue(int index, Dictionary<int, string> values)
+        {
+            if (values.TryGetValue(index, out var value)) return value;
+            return values.Values.First();
+        }
+        private const string fileId = "fileUuid";
+        private const string fileTypeName = "fileTypeName";
+        private const string fileStatusName = "fileStatusName";
+        private const string fileContent = "fileContent";
+        private static readonly Dictionary<int, string> statusNames = new()
+        {
+            {0, "EMPTY" },
+            {10, "ENCODED" },
+            {20, "DECODED" },
+            {30, "DOWNLOADED" }
+        };
+        private static readonly Dictionary<int, string> typeNames = new()
+        {
+            {0, "NONE" },
+            {10, "EXL" },
+            {20, "CSV" },
+            {30, "JSON" }
+        };
+        private static class ProcedureNames
+        {
+            public const string InitProc = "CALL USP_COUNTY_FILE_INITIALIZE_DATA();";
+            public const string GetProc = "CALL USP_COUNTY_FILE_GET_BY_ID( ? );";
+            public const string SetFileTypeProc = "CALL USP_COUNTY_FILE_SET_TYPE( ?, ? );";
+            public const string SetContentAndStatusProc = "CALL USP_COUNTY_FILE_SET_CONTENT_AND_STATUS( ?, ?, ? );";
+        }
+    }
+}

--- a/src/db/component/legallead.jdbc/interfaces/ICountyFileRepository.cs
+++ b/src/db/component/legallead.jdbc/interfaces/ICountyFileRepository.cs
@@ -1,0 +1,13 @@
+﻿using legallead.jdbc.models;
+
+namespace legallead.jdbc.interfaces
+{
+    public interface ICountyFileRepository
+    {
+        Task<bool> InitializeAsync();
+        Task<DbCountyFileModel?> GetContentAsync(DbCountyFileModel request);
+        Task<KeyValuePair<bool, string>> UpdateContentAsync(DbCountyFileModel request);
+        Task<KeyValuePair<bool, string>> UpdateTypeAsync(DbCountyFileModel request);
+        Task<KeyValuePair<bool, string>> UpdateStatusAsync(DbCountyFileModel request);
+    }
+}

--- a/src/db/component/legallead.jdbc/models/DbCountyFileModel.cs
+++ b/src/db/component/legallead.jdbc/models/DbCountyFileModel.cs
@@ -1,0 +1,14 @@
+﻿using legallead.jdbc.attr;
+
+namespace legallead.jdbc.models
+{
+    public class DbCountyFileModel
+    {
+        public string Id { get; set; } = string.Empty;
+        [CountyFileType]
+        public string FileType { get; set; } = string.Empty;
+        [CountyFileStatus]
+        public string FileStatus { get; set; } = string.Empty;
+        public string FileContent { get; set; } = string.Empty;
+    }
+}

--- a/src/db/db.integration.tests/Program.cs
+++ b/src/db/db.integration.tests/Program.cs
@@ -5,25 +5,10 @@
 using db.integration.tests;
 using legallead.jdbc.entities;
 using legallead.jdbc.interfaces;
+using legallead.jdbc.models;
 using Microsoft.Extensions.DependencyInjection;
-int testId = 9;
+int testId = 10;
 var invoicing = ServiceSetup.AppServices.GetRequiredService<IInvoiceRepository>();
-if (testId == 9)
-{
-    var instance = ServiceSetup.AppServices.GetRequiredService<IUserUsageRepository>();
-    var leadId = "fef29532-a487-11ef-99ce-0af7a01f52e9";
-    var dte = new DateTime(2024, 11, 1, 0, 0, 0, DateTimeKind.Utc);
-    var actual = await instance.GetUsageSummary(leadId, dte);
-    Console.WriteLine("Hello, World! {0}. Db result {1}", instance.GetType().FullName, actual);
-}
-if (testId == 8)
-{
-    var instance = ServiceSetup.AppServices.GetRequiredService<IUserUsageRepository>();
-    var leadId = "fef29532-a487-11ef-99ce-0af7a01f52e9";
-    var dte = new DateTime(2024, 11, 1, 0, 0, 0, DateTimeKind.Utc);
-    var actual = await instance.GetUsage(leadId, dte);
-    Console.WriteLine("Hello, World! {0}. Db result {1}", instance.GetType().FullName, actual);
-}
 if (testId == 0)
 {
     var instance = ServiceSetup.AppServices.GetRequiredService<ILeadUserRepository>();
@@ -90,4 +75,56 @@ if (testId == 7)
     var actual = await invoicing.UpdateAsync(updateComplete);
     var count = actual.Key;
     Console.WriteLine("Hello, World! {0}. Db result {1}", invoicing.GetType().FullName, count);
+}
+if (testId == 8)
+{
+    var instance = ServiceSetup.AppServices.GetRequiredService<IUserUsageRepository>();
+    var leadId = "fef29532-a487-11ef-99ce-0af7a01f52e9";
+    var dte = new DateTime(2024, 11, 1, 0, 0, 0, DateTimeKind.Utc);
+    var actual = await instance.GetUsage(leadId, dte);
+    Console.WriteLine("Hello, World! {0}. Db result {1}", instance.GetType().FullName, actual);
+}
+if (testId == 9)
+{
+    var instance = ServiceSetup.AppServices.GetRequiredService<IUserUsageRepository>();
+    var leadId = "fef29532-a487-11ef-99ce-0af7a01f52e9";
+    var dte = new DateTime(2024, 11, 1, 0, 0, 0, DateTimeKind.Utc);
+    var actual = await instance.GetUsageSummary(leadId, dte);
+    Console.WriteLine("Hello, World! {0}. Db result {1}", instance.GetType().FullName, actual);
+}
+if (testId == 10)
+{
+    var request = new DbCountyFileModel
+    {
+        FileContent = "integration test data",
+        Id = "5711f02d-c401-11ef-b422-0af36f7c981d"
+    };
+    var instance = ServiceSetup.AppServices.GetRequiredService<ICountyFileRepository>();
+    var isInitialized = await instance.InitializeAsync();
+    Console.WriteLine("Initialization response: {0}", isInitialized);
+    // update types
+    var typeNames = new string[] { "EXL", "CSV", "JSON", "NONE" };
+    for (int i = 0; i < typeNames.Length; i++)
+    {
+        var type = typeNames[i];
+        request.FileType = type;
+        var isTypeSet = await instance.UpdateTypeAsync(request);
+        Console.WriteLine("Type update response: {0}: {1}", isTypeSet.Key, isTypeSet.Value);
+    }
+    // update status
+    var statusNames = new string[] { "ENCODED", "DECODED", "DOWNLOADED", "EMPTY" };
+    for (int i = 0; i < statusNames.Length; i++)
+    {
+        var status = statusNames[i];
+        request.FileStatus = status;
+        var isStatusSet = await instance.UpdateStatusAsync(request);
+        Console.WriteLine("Status update response: {0}: {1}", isStatusSet.Key, isStatusSet.Value);
+    }
+    // update content
+    for (int i = 0; i < 2; i++)
+    {
+        if (i > 0) request.FileContent = "";
+        var isContentSet = await instance.UpdateContentAsync(request);
+        Console.WriteLine("Content update response: {0}: {1}", isContentSet.Key, isContentSet.Value);
+    }
 }

--- a/src/db/db.integration.tests/ServiceSetup.cs
+++ b/src/db/db.integration.tests/ServiceSetup.cs
@@ -33,6 +33,7 @@ namespace db.integration.tests
                 services.AddScoped<ILeadUserRepository, LeadUserRepository>();
                 services.AddScoped<IInvoiceRepository, InvoiceRepository>();
                 services.AddScoped<IUserUsageRepository, UserUsageRepository>();
+                services.AddScoped<ICountyFileRepository, CountyFileRepository>();
                 Provider = services.BuildServiceProvider();
             }
         }

--- a/src/db/tests/legallead.jdbc.tests/attr/AttributeTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/attr/AttributeTests.cs
@@ -1,0 +1,57 @@
+﻿using legallead.jdbc.attr;
+
+namespace legallead.jdbc.tests.attr
+{
+    public class AttributeTests
+    {
+        [Theory]
+        [InlineData("EMPTY")]
+        [InlineData("ENCODED")]
+        [InlineData("DECODED")]
+        [InlineData("DOWNLOADED")]
+        public void CountyFileStatusAttribute_ValidValues_ShouldPass(string status)
+        {
+            var attribute = new CountyFileStatusAttribute();
+            var result = attribute.IsValid(status);
+            Assert.True(result, $"Expected {status} to be valid.");
+        }
+
+        [Theory]
+        [InlineData("INVALID")]
+        [InlineData("ENCODING")]
+        [InlineData("DECODE")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CountyFileStatusAttribute_InvalidValues_ShouldFail(string status)
+        {
+            var attribute = new CountyFileStatusAttribute();
+            var result = attribute.IsValid(status);
+            Assert.False(result, $"Expected {status} to be invalid.");
+        }
+
+        [Theory]
+        [InlineData("NONE")]
+        [InlineData("EXL")]
+        [InlineData("CSV")]
+        [InlineData("JSON")]
+        public void CountyFileTypeAttribute_ValidValues_ShouldPass(string type)
+        {
+            var attribute = new CountyFileTypeAttribute();
+            var result = attribute.IsValid(type);
+            Assert.True(result, $"Expected {type} to be valid.");
+        }
+
+        [Theory]
+        [InlineData("XML")]
+        [InlineData("TXT")]
+        [InlineData("DOC")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CountyFileTypeAttribute_InvalidValues_ShouldFail(string type)
+        {
+            var attribute = new CountyFileTypeAttribute();
+            var result = attribute.IsValid(type);
+            Assert.False(result, $"Expected {type} to be invalid.");
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/implementations/CountyFileRepositoryTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/implementations/CountyFileRepositoryTests.cs
@@ -16,6 +16,13 @@ namespace legallead.jdbc.tests.implementations
             = new Faker<DbCountyFileModel>()
             .RuleFor(x => x.Id, y => y.Random.AlphaNumeric(25));
 
+        private static readonly Faker<DbCountyFileDto> dtofaker
+            = new Faker<DbCountyFileDto>()
+            .RuleFor(x => x.Id, y => y.Random.AlphaNumeric(25))
+            .RuleFor(x => x.DbCountyFileId, y => y.Random.AlphaNumeric(25))
+            .RuleFor(x => x.FileStatusId, y => y.PickRandom(indexes))
+            .RuleFor(x => x.FileTypeId, y => y.PickRandom(indexes))
+            .RuleFor(x => x.Content, y => y.Hacker.Phrase());
         [Fact]
         public void RepoCanBeConstructed()
         {
@@ -120,6 +127,174 @@ namespace legallead.jdbc.tests.implementations
             });
             Assert.Null(err);
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(true, false)]
+        [InlineData(true, true, false)]
+        public async Task RepoCanUpdateContentAsync(
+            bool canInitialize = true,
+            bool canFetch = true,
+            bool canUpdate = true)
+        {
+
+            var error = new Faker().System.Exception();
+            var provider = new RepoContainer();
+            var mock = provider.CommandMock;
+            var service = provider.Repository;
+            var request = modelfaker.Generate();
+            var response = dtofaker.Generate();
+            if (canInitialize)
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_INITIALIZE_DATA")),
+                    It.IsAny<DynamicParameters>()));
+            }
+            else
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_INITIALIZE_DATA")),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            if (canFetch)
+            {
+                mock.Setup(s => s.QuerySingleOrDefaultAsync<DbCountyFileDto>(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_GET_BY_ID")),
+                    It.IsAny<DynamicParameters>())).ReturnsAsync(response);
+            }
+            else
+            {
+                mock.Setup(s => s.QuerySingleOrDefaultAsync<DbCountyFileDto>(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_GET_BY_ID")),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            if (canUpdate)
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_SET_CONTENT_AND_STATUS")),
+                    It.IsAny<DynamicParameters>()));
+            }
+            else
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_SET_CONTENT_AND_STATUS")),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            var err = await Record.ExceptionAsync(async () =>
+            {
+                await service.UpdateContentAsync(request);
+            });
+            Assert.Null(err);
+        }
+
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RepoCanUpdateTypeAsync(
+            bool canUpdate = true)
+        {
+
+            var error = new Faker().System.Exception();
+            var provider = new RepoContainer();
+            var mock = provider.CommandMock;
+            var service = provider.Repository;
+            var request = modelfaker.Generate();
+            if (canUpdate)
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>()));
+            }
+            else
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            var err = await Record.ExceptionAsync(async () =>
+            {
+                await service.UpdateTypeAsync(request);
+            });
+            Assert.Null(err);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(true, false)]
+        [InlineData(true, true, false)]
+        public async Task RepoCanUpdateStatusAsync(
+            bool canInitialize = true,
+            bool canFetch = true,
+            bool canUpdate = true)
+        {
+
+            var error = new Faker().System.Exception();
+            var provider = new RepoContainer();
+            var mock = provider.CommandMock;
+            var service = provider.Repository;
+            var request = modelfaker.Generate();
+            var response = dtofaker.Generate();
+            if (canInitialize)
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_INITIALIZE_DATA")),
+                    It.IsAny<DynamicParameters>()));
+            }
+            else
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_INITIALIZE_DATA")),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            if (canFetch)
+            {
+                mock.Setup(s => s.QuerySingleOrDefaultAsync<DbCountyFileDto>(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_GET_BY_ID")),
+                    It.IsAny<DynamicParameters>())).ReturnsAsync(response);
+            }
+            else
+            {
+                mock.Setup(s => s.QuerySingleOrDefaultAsync<DbCountyFileDto>(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_GET_BY_ID")),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            if (canUpdate)
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_SET_CONTENT_AND_STATUS")),
+                    It.IsAny<DynamicParameters>()));
+            }
+            else
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.Is<string>(s => s.Contains("USP_COUNTY_FILE_SET_CONTENT_AND_STATUS")),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            var err = await Record.ExceptionAsync(async () =>
+            {
+                await service.UpdateStatusAsync(request);
+            });
+            Assert.Null(err);
+        }
+
+        private static readonly List<int> indexes = [0, 10, 20, 30];
         private sealed class RepoContainer
         {
             private readonly ICountyFileRepository repo;

--- a/src/db/tests/legallead.jdbc.tests/implementations/CountyFileRepositoryTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/implementations/CountyFileRepositoryTests.cs
@@ -1,0 +1,139 @@
+﻿using Bogus;
+using Dapper;
+using legallead.jdbc.entities;
+using legallead.jdbc.helpers;
+using legallead.jdbc.implementations;
+using legallead.jdbc.interfaces;
+using legallead.jdbc.models;
+using Moq;
+using System.Data;
+
+namespace legallead.jdbc.tests.implementations
+{
+    public class CountyFileRepositoryTests
+    {
+        private static readonly Faker<DbCountyFileModel> modelfaker
+            = new Faker<DbCountyFileModel>()
+            .RuleFor(x => x.Id, y => y.Random.AlphaNumeric(25));
+
+        [Fact]
+        public void RepoCanBeConstructed()
+        {
+            var provider = new RepoContainer();
+            var repo = provider.Repository;
+            Assert.NotNull(repo);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        [InlineData(false, 0)]
+        [InlineData(false, 10)]
+        [InlineData(false, 20)]
+        [InlineData(false, 30)]
+        [InlineData(false, 40)]
+        [InlineData(false, null, 0)]
+        [InlineData(false, null, 10)]
+        [InlineData(false, null, 20)]
+        [InlineData(false, null, 30)]
+        [InlineData(false, null, 40)]
+        [InlineData(false, null, null, true)]
+        public async Task RepoCanGetContentAsync(
+            bool canInitialize,
+            int? statusId = null,
+            int? typeId = null,
+            bool hasFetchError = false)
+        {
+            var response = new DbCountyFileDto
+            {
+                FileStatusId = statusId,
+                FileTypeId = typeId,
+            };
+            var error = new Faker().System.Exception();
+            var provider = new RepoContainer();
+            var mock = provider.CommandMock;
+            var service = provider.Repository;
+            var request = modelfaker.Generate();
+            if (canInitialize)
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>()));
+            }
+            else
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            if (hasFetchError)
+            {
+                mock.Setup(s => s.QuerySingleOrDefaultAsync<DbCountyFileDto>(
+                It.IsAny<IDbConnection>(),
+                It.IsAny<string>(),
+                It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            else
+            {
+                mock.Setup(s => s.QuerySingleOrDefaultAsync<DbCountyFileDto>(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ReturnsAsync(response);
+            }
+            var err = await Record.ExceptionAsync(async () =>
+            {
+                await service.GetContentAsync(request);
+            });
+            Assert.Null(err);
+        }
+
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task RepoCanInitializeAsync(
+            bool canInitialize)
+        {
+            var error = new Faker().System.Exception();
+            var provider = new RepoContainer();
+            var mock = provider.CommandMock;
+            var service = provider.Repository;
+            if (canInitialize)
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>()));
+            }
+            else
+            {
+                mock.Setup(s => s.ExecuteAsync(
+                    It.IsAny<IDbConnection>(),
+                    It.IsAny<string>(),
+                    It.IsAny<DynamicParameters>())).ThrowsAsync(error);
+            }
+            var err = await Record.ExceptionAsync(async () =>
+            {
+                await service.InitializeAsync();
+            });
+            Assert.Null(err);
+        }
+        private sealed class RepoContainer
+        {
+            private readonly ICountyFileRepository repo;
+            private readonly Mock<IDapperCommand> command;
+            public RepoContainer()
+            {
+
+                command = new Mock<IDapperCommand>();
+                var dataContext = new DataContext(command.Object);
+                repo = new CountyFileRepository(dataContext);
+            }
+
+            public ICountyFileRepository Repository => repo;
+            public Mock<IDapperCommand> CommandMock => command;
+        }
+    }
+}

--- a/src/db/tests/legallead.jdbc.tests/models/DbCountyFileModelTests.cs
+++ b/src/db/tests/legallead.jdbc.tests/models/DbCountyFileModelTests.cs
@@ -1,0 +1,92 @@
+﻿using Bogus;
+using legallead.jdbc.models;
+using System.ComponentModel.DataAnnotations;
+using ValidationResult = System.ComponentModel.DataAnnotations.ValidationResult;
+
+namespace legallead.jdbc.tests.entities
+{
+    public class DbCountyFileModelTests
+    {
+        [Fact]
+        public void ModelCanCreate()
+        {
+            var error = Record.Exception(() =>
+            {
+                _ = dfaker.Generate();
+            });
+            Assert.Null(error);
+        }
+        [Fact]
+        public void ModelHasExpectedFields()
+        {
+            var error = Record.Exception(() =>
+            {
+                var sut = dfaker.Generate();
+                Assert.NotEqual("", sut.Id);
+                Assert.NotEqual("", sut.FileType);
+                Assert.NotEqual("", sut.FileStatus);
+                Assert.NotEqual("", sut.FileContent);
+            });
+            Assert.Null(error);
+        }
+        [Fact]
+        public void DbCountyFileModel_ValidModel_ShouldPassValidation()
+        {
+            var model = new DbCountyFileModel
+            {
+                Id = "123",
+                FileType = "CSV",
+                FileStatus = "ENCODED",
+                FileContent = "Sample content"
+            };
+
+            var validationResults = ValidateModel(model);
+            Assert.Empty(validationResults);
+        }
+
+        [Fact]
+        public void DbCountyFileModel_InvalidFileType_ShouldFailValidation()
+        {
+            var model = new DbCountyFileModel
+            {
+                Id = "123",
+                FileType = "INVALID",
+                FileStatus = "ENCODED",
+                FileContent = "Sample content"
+            };
+
+            var validationResults = ValidateModel(model);
+            Assert.Contains(validationResults, v => v.MemberNames.Contains(nameof(DbCountyFileModel.FileType)));
+        }
+
+        [Fact]
+        public void DbCountyFileModel_InvalidFileStatus_ShouldFailValidation()
+        {
+            var model = new DbCountyFileModel
+            {
+                Id = "123",
+                FileType = "CSV",
+                FileStatus = "INVALID",
+                FileContent = "Sample content"
+            };
+
+            var validationResults = ValidateModel(model);
+            Assert.Contains(validationResults, v => v.MemberNames.Contains(nameof(DbCountyFileModel.FileStatus)));
+        }
+
+        private static List<ValidationResult> ValidateModel(object model)
+        {
+            var validationResults = new List<ValidationResult>();
+            var validationContext = new ValidationContext(model, null, null);
+            Validator.TryValidateObject(model, validationContext, validationResults, true);
+            return validationResults;
+        }
+
+        private static readonly Faker<DbCountyFileModel> dfaker
+            = new Faker<DbCountyFileModel>()
+            .RuleFor(x => x.Id, y => y.Random.Guid().ToString())
+            .RuleFor(x => x.FileType, y => y.Lorem.Word())
+            .RuleFor(x => x.FileStatus, y => y.Lorem.Word())
+            .RuleFor(x => x.FileContent, y => y.Hacker.Phrase());
+    }
+}


### PR DESCRIPTION
# Context:
In order to support objective to allow file storage of a user search result in the repository, I want the database to expose methods to:

- Save a fetch result
- Update a fetch result
- Retrieve a fetch result

## Implementation
New repository is created with methods to create, read and update search details.
No method is exposed or supported to delete these records.