### PR TITLE
PR | API | Dallas Offline Search Enhancement

### DIFF
--- a/release/legallead.permissions.api.release.json
+++ b/release/legallead.permissions.api.release.json
@@ -1,5 +1,10 @@
 [
 	{
+		"name": "3.2.469.--",
+		"description": "API - offline - allow db lookup support",
+		"date": "2025-05-12 13:15:00"
+	},
+	{
 		"name": "3.2.468.--",
 		"description": "API - download - release artifacts",
 		"date": "2025-04-24 16:45:00"

--- a/src/api/legallead.permissions.api/Controllers/DbController.cs
+++ b/src/api/legallead.permissions.api/Controllers/DbController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using page.load.utility;
 using page.load.utility.Entities;
 using page.load.utility.Extensions;
+using page.load.utility.Interfaces;
 using System.Collections.ObjectModel;
 using System.Globalization;
 
@@ -15,13 +16,15 @@ namespace legallead.permissions.api.Controllers
     IDbHistoryService db,
     IHolidayService holidayDb,
     IUserUsageService usageDb,
-    ICountyFileService fileDb) : ControllerBase
+    ICountyFileService fileDb,
+    IFetchDbAddress findAddressService) : ControllerBase
     {
         private readonly ILeadAuthenicationService _leadService = lead;
         private readonly IDbHistoryService _dataService = db;
         private readonly IHolidayService _holidayService = holidayDb;
         private readonly IUserUsageService _usageService = usageDb;
         private readonly ICountyFileService _fileService = fileDb;
+        private readonly IFetchDbAddress _addressService = findAddressService;
 
         [HttpPost("begin")]
         public async Task<IActionResult> BeginAsync(BeginDataRequest model)
@@ -233,13 +236,10 @@ namespace legallead.permissions.api.Controllers
                 Guid.NewGuid().ToString("D") : model.OfflineId;
             response.OfflineRequestId = objRequestGuid;
             offlineRequests.Add(response);
-            // need to create an instance of new interface that fetches address from db
-            // this allows the reader to get from db in place of http call when data
-            // has already been read
             var service = new BulkCaseReader(
                 new ReadOnlyCollection<OpenQA.Selenium.Cookie>(cookies),
                 items,
-                new BulkReadMessages { OfflineRequestId = objRequestGuid })
+                new BulkReadMessages { OfflineRequestId = objRequestGuid, AddressSerice = _addressService })
             {
                 OnStatusUpdated = StatusChanged,
                 OnStatusTimeOut = StatusTerminated

--- a/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
+++ b/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
@@ -44,5 +44,6 @@ namespace legallead.permissions.api.Interfaces
         Task UpdateOfflineHistoryAsync();
         Task UpdateOfflineSearchTypesAsync();
         Task<List<OfflineSearchTypeBo>> GetOfflineSearchTypesByIdAsync(string leadId);
+        Task<string?> FindCaseItemByCaseNumberAsync(int countyId, string caseNumber);
     }
 }

--- a/src/api/legallead.permissions.api/ObjectExtensions.cs
+++ b/src/api/legallead.permissions.api/ObjectExtensions.cs
@@ -16,6 +16,7 @@ using legallead.Profiles.api.Controllers;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
+using page.load.utility.Interfaces;
 using Stripe;
 using System.ComponentModel.DataAnnotations;
 using System.Text;
@@ -228,6 +229,12 @@ namespace legallead.permissions.api
             {
                 var lg = p.GetRequiredService<ILoggingService>();
                 return new LoggingInfrastructure(lg);
+            });
+            // case detail lookup service
+            services.AddScoped<IFetchDbAddress>(p =>
+            {
+                var lg = p.GetRequiredService<IUserUsageService>();
+                return new CaseDetailLookupService(lg);
             });
 
             var loggerFactory = LoggerFactory.Create(loggingBuilder => loggingBuilder

--- a/src/api/legallead.permissions.api/Services/CaseDetailLookupService.cs
+++ b/src/api/legallead.permissions.api/Services/CaseDetailLookupService.cs
@@ -1,0 +1,22 @@
+﻿using legallead.permissions.api.Extensions;
+using page.load.utility.Entities;
+using page.load.utility.Interfaces;
+
+namespace legallead.permissions.api.Services
+{
+    public class CaseDetailLookupService(IUserUsageService usageDb) : IFetchDbAddress
+    {
+        private readonly IUserUsageService db = usageDb;
+
+        public TheAddress? FindAddress(int countyId, string caseNumber)
+        {
+            var db_item = db.FindCaseItemByCaseNumberAsync(countyId, caseNumber)
+                .GetAwaiter()
+                .GetResult();
+            if (string.IsNullOrEmpty(db_item)) return default;
+            var address = db_item.ToInstance<TheAddress>();
+            if (address == null || !address.IsValid || address.Zip.Equals("00000")) return default;
+            return address;
+        }
+    }
+}

--- a/src/api/legallead.permissions.api/Services/UserUsageService.cs
+++ b/src/api/legallead.permissions.api/Services/UserUsageService.cs
@@ -155,12 +155,10 @@ namespace legallead.permissions.api.Services
         }
         public async Task<string?> FindCaseItemByCaseNumberAsync(int countyId, string caseNumber)
         {
-            var model = new { CountyId = countyId, CaseNumber = caseNumber };
-            var response = await Task.Run(() =>
-            {
-                return model.CountyId % 2 == 0 ? model.CaseNumber : null;
-            });
-            return response;
+            var model = new OfflineCaseItemModel { CountyId = countyId, CaseNumber = caseNumber };
+            var data = await db.OfflineFindByCaseNumber(model);
+            if (data == null) return null;
+            return data.ToJsonString();
         }
 
         private static string Serialize(object? value)

--- a/src/api/legallead.permissions.api/Services/UserUsageService.cs
+++ b/src/api/legallead.permissions.api/Services/UserUsageService.cs
@@ -153,6 +153,15 @@ namespace legallead.permissions.api.Services
             if (data == null || data.Count == 0) return [];
             return DeSerialize<List<OfflineSearchTypeBo>>(Serialize(data)) ?? [];
         }
+        public async Task<string?> FindCaseItemByCaseNumberAsync(int countyId, string caseNumber)
+        {
+            var model = new { CountyId = countyId, CaseNumber = caseNumber };
+            var response = await Task.Run(() =>
+            {
+                return model.CountyId % 2 == 0 ? model.CaseNumber : null;
+            });
+            return response;
+        }
 
         private static string Serialize(object? value)
         {

--- a/src/api/legallead.permissions.api/legallead.permissions.api.csproj
+++ b/src/api/legallead.permissions.api/legallead.permissions.api.csproj
@@ -69,7 +69,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Polly" Version="8.5.2" />
 		<PackageReference Include="Stripe.net" Version="47.4.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="7.1.0" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.9.0" />
 	</ItemGroup>
 	

--- a/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
+++ b/src/api/permissions.api.tests/Contollers/BaseControllerTest.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
+using page.load.utility.Interfaces;
 
 namespace permissions.api.tests.Contollers
 {
@@ -80,6 +81,7 @@ namespace permissions.api.tests.Contollers
                 var mkoption = new Mock<PaymentStripeOption>();
                 var mkInvoiceSvc = new Mock<ILeadInvoiceService>();
                 var mkFileSvc = new Mock<ICountyFileService>();
+                var caseLookupService = new Mock<IFetchDbAddress>();
                 var collection = new ServiceCollection();
                 collection.AddScoped<ICountyAuthorizationService, CountyAuthorizationService>();
                 collection.AddScoped<IAppAuthenicationService, AppAuthenicationService>();
@@ -142,6 +144,8 @@ namespace permissions.api.tests.Contollers
                 collection.AddScoped(s => mkInvoiceSvc.Object);
                 collection.AddScoped(s => mkFileSvc);
                 collection.AddScoped(s => mkFileSvc.Object);
+                collection.AddScoped(s => caseLookupService);
+                collection.AddScoped(s => caseLookupService.Object);
                 collection.AddScoped<ILeadSecurityService, LeadSecurityService>();
                 collection.AddScoped(p =>
                 {
@@ -232,6 +236,7 @@ namespace permissions.api.tests.Contollers
                     var datesvc = a.GetRequiredService<IHolidayService>();
                     var usagesvc = a.GetRequiredService<IUserUsageService>();
                     var fileSvc = a.GetRequiredService<ICountyFileService>();
+                    var addressSvc = a.GetRequiredService<IFetchDbAddress>();
                     var headers = new HeaderDictionary
                     {
                         {
@@ -240,7 +245,7 @@ namespace permissions.api.tests.Contollers
                         }
                     };
                     mqRequest.SetupGet(m => m.Headers).Returns(headers);
-                    return new DbController(leadsvc, mqDb, datesvc, usagesvc, fileSvc)
+                    return new DbController(leadsvc, mqDb, datesvc, usagesvc, fileSvc, addressSvc)
                     {
                         ControllerContext = controllerContext
                     };

--- a/src/page.load.utility/Entities/BulkReadMessages.cs
+++ b/src/page.load.utility/Entities/BulkReadMessages.cs
@@ -1,4 +1,6 @@
-﻿namespace page.load.utility.Entities
+﻿using page.load.utility.Interfaces;
+
+namespace page.load.utility.Entities
 {
     public class BulkReadMessages
     {
@@ -8,5 +10,6 @@
         public int TotalProcessed { get; set; }
         public string Workload { get; set; } = string.Empty;
         public int RetryCount { get; set; }
+        public IFetchDbAddress? AddressSerice { get; set; } = null;
     }
 }

--- a/src/page.load.utility/Entities/BulkReadMessages.cs
+++ b/src/page.load.utility/Entities/BulkReadMessages.cs
@@ -11,5 +11,6 @@ namespace page.load.utility.Entities
         public string Workload { get; set; } = string.Empty;
         public int RetryCount { get; set; }
         public IFetchDbAddress? AddressSerice { get; set; } = null;
+        public int CountyId { get; set; } = 60;
     }
 }

--- a/src/page.load.utility/Entities/CaseItemDtoMapper.cs
+++ b/src/page.load.utility/Entities/CaseItemDtoMapper.cs
@@ -15,6 +15,7 @@ namespace page.load.utility.Entities
             Dto.CaseStyle = src.CaseHeader;
             Dto.Plaintiff = src.Plaintiff;
             if (!string.IsNullOrWhiteSpace(src.Address)) Dto.Address = src.Address;
+            if (string.IsNullOrEmpty(Dto.PartyName) && !string.IsNullOrEmpty(src.PersonName)) Dto.PartyName = src.PersonName;
         }
         public bool IsMapped()
         {

--- a/src/page.load.utility/Entities/TheAddress.cs
+++ b/src/page.load.utility/Entities/TheAddress.cs
@@ -8,6 +8,8 @@ namespace page.load.utility.Entities
         [JsonProperty("plaintiff")] public string Plaintiff { get; set; } = string.Empty;
         [JsonProperty("casenbr")] public string CaseNumber { get; set; } = string.Empty;
         [JsonProperty("caseheader")] public string CaseHeader { get; set; } = string.Empty;
+        public string PersonName { get; set; } = string.Empty;
+        public string Zip { get; set; } = string.Empty;
         public bool IsValid
         {
             get

--- a/src/page.load.utility/Interfaces/IFetchDbAddress.cs
+++ b/src/page.load.utility/Interfaces/IFetchDbAddress.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using page.load.utility.Entities;
+﻿using page.load.utility.Entities;
 
 namespace page.load.utility.Interfaces
 {
     public interface IFetchDbAddress
     {
-        public TheAddress FindAddress(int countyId, string caseNumber);
+        public TheAddress? FindAddress(int countyId, string caseNumber);
     }
 }


### PR DESCRIPTION
## Topic
When Dallas search performs offline search then the search has the ability to read from database to prevent and reduce onneeded http requests.