### PR TITLE
PR | API | Support offline processing in background

### DIFF
--- a/release/legallead.permissions.api.release.json
+++ b/release/legallead.permissions.api.release.json
@@ -1,5 +1,10 @@
 [
 	{
+		"name": "3.2.470.--",
+		"description": "API - offline - allow db lookup support",
+		"date": "2025-05-12 16:30:00"
+	},
+	{
 		"name": "3.2.469.--",
 		"description": "API - offline - allow db lookup support",
 		"date": "2025-05-12 13:15:00"

--- a/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
+++ b/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
@@ -45,6 +45,6 @@ namespace legallead.permissions.api.Interfaces
         Task UpdateOfflineSearchTypesAsync();
         Task<List<OfflineSearchTypeBo>> GetOfflineSearchTypesByIdAsync(string leadId);
         Task<string?> FindCaseItemByCaseNumberAsync(int countyId, string caseNumber);
-        Task<IEnumerable<OfflineDataModel>?> GetOfflineWorkQueueAsync();
+        Task<List<OfflineDataModel>?> GetOfflineWorkQueueAsync();
     }
 }

--- a/src/api/legallead.permissions.api/Services/BackgroundBulkReaderService.cs
+++ b/src/api/legallead.permissions.api/Services/BackgroundBulkReaderService.cs
@@ -31,8 +31,14 @@ namespace legallead.permissions.api.Services
                     var usageDb = svc._usageService;
                     var addressSvc = svc._addressSvc;
                     var queue = await usageDb.GetOfflineWorkQueueAsync();
-                    if (queue == null || !queue.Any()) return;
+                    if (queue == null || queue.Count == 0) return;
                     var list = queue.ToList();
+                    var working = offlineRequests.Select(x => x.OfflineRequestId);
+                    list.RemoveAll(x => string.IsNullOrEmpty(x.RequestId));
+                    list.RemoveAll(x => string.IsNullOrEmpty(x.Cookie));
+                    list.RemoveAll(x => string.IsNullOrEmpty(x.Workload));
+                    list.RemoveAll(x => working.Contains(x.OfflineId));
+                    if (list.Count == 0) return;
                     foreach (var request in list)
                     {
                         var response = new BulkReadResponse { RequestId = request.RequestId };

--- a/src/api/legallead.permissions.api/Services/UserUsageService.cs
+++ b/src/api/legallead.permissions.api/Services/UserUsageService.cs
@@ -3,6 +3,7 @@ using legallead.jdbc.interfaces;
 using legallead.permissions.api.Extensions;
 using legallead.permissions.api.Models;
 using Newtonsoft.Json;
+using StructureMap.Query;
 
 namespace legallead.permissions.api.Services
 {
@@ -160,12 +161,11 @@ namespace legallead.permissions.api.Services
             if (data == null) return null;
             return data.ToJsonString();
         }
-        public async Task<IEnumerable<OfflineDataModel>?> GetOfflineWorkQueueAsync()
+        public async Task<List<OfflineDataModel>?> GetOfflineWorkQueueAsync()
         {
-            var data = await Task.Run(() => { 
-                return new List<OfflineDataModel>(); 
-            });
-            return data;
+            var data = await db.GetOfflineWorkQueueAsync();
+            if (data == null || data.Count == 0) return [];
+            return DeSerialize<List<OfflineDataModel>>(Serialize(data)) ?? [];
         }
         private static string Serialize(object? value)
         {

--- a/src/api/permissions.api.tests/Others/RegisterDataServicesTests.cs
+++ b/src/api/permissions.api.tests/Others/RegisterDataServicesTests.cs
@@ -139,7 +139,7 @@ namespace permissions.api.tests
         [Fact]
         public void ProviderCanGetStartupTasks()
         {
-            const int expected = 2;
+            const int expected = 3;
             var startupTasks = _serviceProvider?.GetServices<IStartupTask>();
             Assert.NotNull(startupTasks);
             Assert.Equal(expected, startupTasks.Count());


### PR DESCRIPTION
## Context
As an API,  
I want to fetch records for user submitted requests  
So that no user interaction is required to ensure data read is completed successfully.
