### PR TITLE
feat: api allow db call to fetch admin status

### DIFF
--- a/release/legallead.permissions.api.release.json
+++ b/release/legallead.permissions.api.release.json
@@ -1,5 +1,10 @@
 [
 	{
+		"name": "3.2.476.--",
+		"description": "API - lead - get admin status sproc",
+		"date": "2025-06-11 21:45:00"
+	},
+	{
 		"name": "3.2.475.--",
 		"description": "API - invoice creation",
 		"date": "2025-06-10 19:15:00"

--- a/src/api/legallead.permissions.api/Controllers/DbInvoicingController.cs
+++ b/src/api/legallead.permissions.api/Controllers/DbInvoicingController.cs
@@ -142,9 +142,10 @@ namespace legallead.permissions.api.Controllers
             if (user == null) return false;
             var hasZero = response.Headers.Any(x => x.InvoiceTotal.GetValueOrDefault() < 0.02m);
             if (!hasZero) return false;
-            var data = user.CountyData.ToInstance<List<CountyDataModel>>();
-            if (data == null || data.Count == 0) return false;
-            return data.Exists(x => x.MonthlyLimit.GetValueOrDefault() != -1);
+            var data = _usageService.GetUserAdminStatusAsync(user.Id).Result;
+            if (data == null) return false;
+            if (data.IsAdmin.GetValueOrDefault()) return false;
+            return true;
         }
 
         private string GetBillingType(HttpRequest request)
@@ -166,11 +167,5 @@ namespace legallead.permissions.api.Controllers
         private static readonly StringComparer ooic = StringComparer.OrdinalIgnoreCase;
         private const StringComparison oic = StringComparison.OrdinalIgnoreCase;
         private const string UserAccountAccess = "user account access credential";
-        private class CountyDataModel
-        {
-            public string LeadUserId { get; set; } = string.Empty;
-            public string CountyName { get; set; } = string.Empty;
-            public int? MonthlyLimit { get; set; }
-        }
     }
 }

--- a/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
+++ b/src/api/legallead.permissions.api/Interfaces/IUserUsageService.cs
@@ -50,5 +50,6 @@ namespace legallead.permissions.api.Interfaces
         Task<List<MyProfileBo>> UpdateUserProfileAsync(string leadId, List<MyProfileBo> updates);
         Task<string> GetUserBillingTypeAsync(string leadId);
         Task<string> SetUserBillingTypeAsync(string leadId, string paymentCode);
+        Task<GetAdminStatusBo?> GetUserAdminStatusAsync(string leadId);
     }
 }

--- a/src/api/legallead.permissions.api/Services/UserUsageService.cs
+++ b/src/api/legallead.permissions.api/Services/UserUsageService.cs
@@ -199,6 +199,12 @@ namespace legallead.permissions.api.Services
             return response.ToUpper();
         }
 
+        public async Task<GetAdminStatusBo?> GetUserAdminStatusAsync(string leadId)
+        {
+            var data = await db.GetUserAdminStatusAsync(leadId);
+            return data;
+        }
+
         private static string Serialize(object? value)
         {
             if (value == null) return string.Empty;


### PR DESCRIPTION
As a API,
I want to read database to get user admin status,
So that my requests are always using the source of truth.